### PR TITLE
TRE-31: Backend data models and SQLite persistence layer

### DIFF
--- a/.orca/state.json
+++ b/.orca/state.json
@@ -1,35 +1,25 @@
 {
   "issue": "TRE-31",
-  "agent": "implementation",
-  "step": "completed",
-  "scope_score": 6,
-  "decision": "ATOMIC",
-  "artifacts": {
-    "scope_report": "docs/plans/TRE-31-scope.md",
-    "implementation_plan": "docs/plans/TRE-31-plan.md",
-    "feedback_loop": "docs/feedback-loops/TRE-31-feedback.md",
-    "doc_impact": "docs/plans/TRE-31-doc-impact.md"
-  },
-  "affected_files": [
-    "backend/src/app/models.py",
-    "backend/src/app/database.py",
-    "backend/pyproject.toml",
-    "backend/tests/test_models.py",
-    "backend/tests/test_database.py"
-  ],
-  "subsystems": ["data_models", "persistence"],
-  "implementation": {
-    "steps_completed": ["step-1", "step-2", "step-3", "step-4", "step-5"],
-    "tests_passing": {
-      "test_models": 12,
-      "test_database": 23,
-      "test_smoke": 1,
-      "total": 36
-    },
-    "all_tests_green": true,
-    "lint_clean": true,
-    "format_clean": true
+  "agent": "docs",
+  "step": "updating-docs",
+  "pr_url": "https://github.com/gutnikov/trello-clone/pull/4",
+  "pr_number": 4,
+  "branch": "TRE-31",
+  "push_completed": true,
+  "pr_created": true,
+  "ci_status": "pass",
+  "ci_checks": {
+    "Test": "SUCCESS",
+    "Lint & Format": "SUCCESS",
+    "Deploy PR Preview": "SUCCESS",
+    "E2E Tests": "SUCCESS"
   },
   "retry_count": 0,
-  "status": "success"
+  "doc_updates_completed": [
+    "docs/architecture/adr-001-sqlite-persistence.md",
+    "docs/agents/implementation.md",
+    "README.md"
+  ],
+  "doc_updates_pending": [],
+  "status": "in_progress"
 }

--- a/.orca/state.json
+++ b/.orca/state.json
@@ -1,0 +1,24 @@
+{
+  "issue": "TRE-31",
+  "agent": "planning",
+  "step": "completed",
+  "scope_score": 6,
+  "decision": "ATOMIC",
+  "artifacts": {
+    "scope_report": "docs/plans/TRE-31-scope.md",
+    "implementation_plan": "docs/plans/TRE-31-plan.md",
+    "feedback_loop": "docs/feedback-loops/TRE-31-feedback.md",
+    "doc_impact": "docs/plans/TRE-31-doc-impact.md"
+  },
+  "affected_files": [
+    "backend/src/app/models.py",
+    "backend/src/app/database.py",
+    "backend/pyproject.toml",
+    "backend/tests/test_models.py",
+    "backend/tests/test_database.py"
+  ],
+  "subsystems": ["data_models", "persistence"],
+  "feedback_completeness_score": 7,
+  "retry_count": 0,
+  "status": "success"
+}

--- a/.orca/state.json
+++ b/.orca/state.json
@@ -1,6 +1,6 @@
 {
   "issue": "TRE-31",
-  "agent": "planning",
+  "agent": "implementation",
   "step": "completed",
   "scope_score": 6,
   "decision": "ATOMIC",
@@ -18,7 +18,18 @@
     "backend/tests/test_database.py"
   ],
   "subsystems": ["data_models", "persistence"],
-  "feedback_completeness_score": 7,
+  "implementation": {
+    "steps_completed": ["step-1", "step-2", "step-3", "step-4", "step-5"],
+    "tests_passing": {
+      "test_models": 12,
+      "test_database": 23,
+      "test_smoke": 1,
+      "total": 36
+    },
+    "all_tests_green": true,
+    "lint_clean": true,
+    "format_clean": true
+  },
   "retry_count": 0,
   "status": "success"
 }

--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
 # trello-clone
+
+A Trello-style kanban board application.
+
+## Tech Stack
+
+| Layer    | Technology                        |
+|----------|-----------------------------------|
+| Frontend | Astro, React, TypeScript          |
+| Backend  | FastAPI, Python 3.12+             |
+| Database | SQLite (via aiosqlite)            |
+| Logging  | structlog (JSON to stdout)        |
+
+## Getting Started
+
+```bash
+make install    # Install all dependencies (backend + frontend)
+make dev        # Start backend (port 8000) and frontend (port 3000)
+make test       # Run all tests
+make lint       # Run all linters
+```

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -7,6 +7,7 @@ dependencies = [
     "fastapi>=0.115.0",
     "uvicorn[standard]>=0.34.0",
     "structlog>=24.0.0",
+    "aiosqlite>=0.20.0",
 ]
 
 [project.optional-dependencies]

--- a/backend/src/app/database.py
+++ b/backend/src/app/database.py
@@ -1,0 +1,106 @@
+"""SQLite persistence layer for the Trello clone backend.
+
+Stub module — implementation pending (TRE-31).
+Methods are importable but not yet implemented with correct behavior.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import aiosqlite
+
+from app.models import Board, Card, List
+
+
+class Database:
+    """SQLite persistence layer stub — not yet implemented."""
+
+    _conn: aiosqlite.Connection | None
+
+    def __init__(self, db_path: str | Path = ":memory:") -> None:
+        self.db_path = db_path
+        self._conn = None
+
+    async def connect(self) -> None:
+        """Open database connection — stub, does nothing."""
+
+    async def close(self) -> None:
+        """Close database connection — stub, does nothing."""
+
+    async def init_schema(self) -> None:
+        """Initialize database schema — stub, does nothing."""
+
+    async def seed_default_board(self) -> Board:
+        """Seed default board — stub, returns empty board."""
+        return Board()
+
+    async def create_board(self, board: Board) -> Board:
+        """Create a board — stub, returns empty board."""
+        return Board()
+
+    async def get_board(self, board_id: str) -> Board | None:
+        """Get a board by ID — stub, returns None."""
+        return None
+
+    async def list_boards(self) -> list[Board]:
+        """List all boards — stub, returns empty list."""
+        return []
+
+    async def update_board(self, board_id: str, title: str) -> Board | None:
+        """Update a board — stub, returns None."""
+        return None
+
+    async def delete_board(self, board_id: str) -> bool:
+        """Delete a board — stub, returns False."""
+        return False
+
+    async def create_list(self, lst: List) -> List:
+        """Create a list — stub, returns empty list model."""
+        return List()
+
+    async def get_list(self, list_id: str) -> List | None:
+        """Get a list by ID — stub, returns None."""
+        return None
+
+    async def get_lists_by_board(self, board_id: str) -> list[List]:
+        """Get lists by board — stub, returns empty list."""
+        return []
+
+    async def update_list(
+        self, list_id: str, title: str | None = None, position: int | None = None
+    ) -> List | None:
+        """Update a list — stub, returns None."""
+        return None
+
+    async def delete_list(self, list_id: str) -> bool:
+        """Delete a list — stub, returns False."""
+        return False
+
+    async def create_card(self, card: Card) -> Card:
+        """Create a card — stub, returns empty card model."""
+        return Card()
+
+    async def get_card(self, card_id: str) -> Card | None:
+        """Get a card by ID — stub, returns None."""
+        return None
+
+    async def get_cards_by_list(self, list_id: str) -> list[Card]:
+        """Get cards by list — stub, returns empty list."""
+        return []
+
+    async def update_card(
+        self,
+        card_id: str,
+        title: str | None = None,
+        position: int | None = None,
+        list_id: str | None = None,
+    ) -> Card | None:
+        """Update a card — stub, returns None."""
+        return None
+
+    async def delete_card(self, card_id: str) -> bool:
+        """Delete a card — stub, returns False."""
+        return False

--- a/backend/src/app/database.py
+++ b/backend/src/app/database.py
@@ -1,95 +1,230 @@
 """SQLite persistence layer for the Trello clone backend.
 
-Stub module — implementation pending (TRE-31).
-Methods are importable but not yet implemented with correct behavior.
+Provides async CRUD operations for Board, List, and Card entities
+using aiosqlite with WAL mode and foreign key enforcement.
 """
 
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
-    import aiosqlite
+import aiosqlite
 
+from app.logging import get_logger
 from app.models import Board, Card, List
+
+log = get_logger(module="database")
 
 
 class Database:
-    """SQLite persistence layer stub — not yet implemented."""
+    """Async SQLite persistence layer for boards, lists, and cards."""
 
     _conn: aiosqlite.Connection | None
 
-    def __init__(self, db_path: str | Path = ":memory:") -> None:
-        self.db_path = db_path
+    def __init__(self, db_path: str | Path = "data/trello.db") -> None:
+        self.db_path = str(db_path)
         self._conn = None
 
     async def connect(self) -> None:
-        """Open database connection — stub, does nothing."""
+        """Open database connection, enable WAL mode and foreign keys."""
+        self._conn = await aiosqlite.connect(self.db_path)
+        await self._conn.execute("PRAGMA journal_mode=WAL")
+        await self._conn.execute("PRAGMA foreign_keys=ON")
+        log.info("database_connected", db_path=self.db_path)
 
     async def close(self) -> None:
-        """Close database connection — stub, does nothing."""
+        """Close the database connection."""
+        if self._conn is not None:
+            await self._conn.close()
+            self._conn = None
+            log.info("database_closed")
 
     async def init_schema(self) -> None:
-        """Initialize database schema — stub, does nothing."""
+        """Create tables if they don't exist."""
+        assert self._conn is not None, "Database not connected"
+        await self._conn.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS boards (
+                id TEXT PRIMARY KEY,
+                title TEXT NOT NULL
+            );
+            CREATE TABLE IF NOT EXISTS lists (
+                id TEXT PRIMARY KEY,
+                title TEXT NOT NULL,
+                board_id TEXT NOT NULL,
+                position INTEGER NOT NULL DEFAULT 0,
+                FOREIGN KEY (board_id) REFERENCES boards(id) ON DELETE CASCADE
+            );
+            CREATE TABLE IF NOT EXISTS cards (
+                id TEXT PRIMARY KEY,
+                title TEXT NOT NULL,
+                list_id TEXT NOT NULL,
+                position INTEGER NOT NULL DEFAULT 0,
+                FOREIGN KEY (list_id) REFERENCES lists(id) ON DELETE CASCADE
+            );
+            """
+        )
+        await self._conn.commit()
+        log.info("schema_initialized")
 
     async def seed_default_board(self) -> Board:
-        """Seed default board — stub, returns empty board."""
-        return Board()
+        """Seed a default board if none exist. Idempotent."""
+        assert self._conn is not None, "Database not connected"
+        cursor = await self._conn.execute("SELECT id, title FROM boards LIMIT 1")
+        row = await cursor.fetchone()
+        if row is not None:
+            log.info("seed_default_board_skipped", reason="board_exists")
+            return Board(id=row[0], title=row[1])
+        board = Board(title="My Board")
+        await self._conn.execute(
+            "INSERT INTO boards (id, title) VALUES (?, ?)",
+            (board.id, board.title),
+        )
+        await self._conn.commit()
+        log.info("seed_default_board_created", board_id=board.id)
+        return board
+
+    # ── Board CRUD ──────────────────────────────────────────────────────
 
     async def create_board(self, board: Board) -> Board:
-        """Create a board — stub, returns empty board."""
-        return Board()
+        """Insert a board into the database."""
+        assert self._conn is not None, "Database not connected"
+        await self._conn.execute(
+            "INSERT INTO boards (id, title) VALUES (?, ?)",
+            (board.id, board.title),
+        )
+        await self._conn.commit()
+        return board
 
     async def get_board(self, board_id: str) -> Board | None:
-        """Get a board by ID — stub, returns None."""
-        return None
+        """Retrieve a board by ID, or None if not found."""
+        assert self._conn is not None, "Database not connected"
+        cursor = await self._conn.execute("SELECT id, title FROM boards WHERE id = ?", (board_id,))
+        row = await cursor.fetchone()
+        if row is None:
+            return None
+        return Board(id=row[0], title=row[1])
 
     async def list_boards(self) -> list[Board]:
-        """List all boards — stub, returns empty list."""
-        return []
+        """Return all boards."""
+        assert self._conn is not None, "Database not connected"
+        cursor = await self._conn.execute("SELECT id, title FROM boards")
+        rows = await cursor.fetchall()
+        return [Board(id=row[0], title=row[1]) for row in rows]
 
     async def update_board(self, board_id: str, title: str) -> Board | None:
-        """Update a board — stub, returns None."""
-        return None
+        """Update a board's title. Returns updated board or None if not found."""
+        assert self._conn is not None, "Database not connected"
+        cursor = await self._conn.execute(
+            "UPDATE boards SET title = ? WHERE id = ?", (title, board_id)
+        )
+        await self._conn.commit()
+        if cursor.rowcount == 0:
+            return None
+        return await self.get_board(board_id)
 
     async def delete_board(self, board_id: str) -> bool:
-        """Delete a board — stub, returns False."""
-        return False
+        """Delete a board by ID. Returns True if deleted, False if not found."""
+        assert self._conn is not None, "Database not connected"
+        cursor = await self._conn.execute("DELETE FROM boards WHERE id = ?", (board_id,))
+        await self._conn.commit()
+        return cursor.rowcount > 0
+
+    # ── List CRUD ───────────────────────────────────────────────────────
 
     async def create_list(self, lst: List) -> List:
-        """Create a list — stub, returns empty list model."""
-        return List()
+        """Insert a list into the database."""
+        assert self._conn is not None, "Database not connected"
+        await self._conn.execute(
+            "INSERT INTO lists (id, title, board_id, position) VALUES (?, ?, ?, ?)",
+            (lst.id, lst.title, lst.board_id, lst.position),
+        )
+        await self._conn.commit()
+        return lst
 
     async def get_list(self, list_id: str) -> List | None:
-        """Get a list by ID — stub, returns None."""
-        return None
+        """Retrieve a list by ID, or None if not found."""
+        assert self._conn is not None, "Database not connected"
+        cursor = await self._conn.execute(
+            "SELECT id, title, board_id, position FROM lists WHERE id = ?", (list_id,)
+        )
+        row = await cursor.fetchone()
+        if row is None:
+            return None
+        return List(id=row[0], title=row[1], board_id=row[2], position=row[3])
 
     async def get_lists_by_board(self, board_id: str) -> list[List]:
-        """Get lists by board — stub, returns empty list."""
-        return []
+        """Return all lists for a board, ordered by position."""
+        assert self._conn is not None, "Database not connected"
+        cursor = await self._conn.execute(
+            "SELECT id, title, board_id, position FROM lists WHERE board_id = ? ORDER BY position",
+            (board_id,),
+        )
+        rows = await cursor.fetchall()
+        return [List(id=row[0], title=row[1], board_id=row[2], position=row[3]) for row in rows]
 
     async def update_list(
         self, list_id: str, title: str | None = None, position: int | None = None
     ) -> List | None:
-        """Update a list — stub, returns None."""
-        return None
+        """Update a list's title and/or position. Returns updated list or None."""
+        assert self._conn is not None, "Database not connected"
+        updates: list[str] = []
+        params: list[str | int] = []
+        if title is not None:
+            updates.append("title = ?")
+            params.append(title)
+        if position is not None:
+            updates.append("position = ?")
+            params.append(position)
+        if not updates:
+            return await self.get_list(list_id)
+        params.append(list_id)
+        query = f"UPDATE lists SET {', '.join(updates)} WHERE id = ?"  # noqa: S608
+        cursor = await self._conn.execute(query, params)
+        await self._conn.commit()
+        if cursor.rowcount == 0:
+            return None
+        return await self.get_list(list_id)
 
     async def delete_list(self, list_id: str) -> bool:
-        """Delete a list — stub, returns False."""
-        return False
+        """Delete a list by ID. Returns True if deleted, False if not found."""
+        assert self._conn is not None, "Database not connected"
+        cursor = await self._conn.execute("DELETE FROM lists WHERE id = ?", (list_id,))
+        await self._conn.commit()
+        return cursor.rowcount > 0
+
+    # ── Card CRUD ───────────────────────────────────────────────────────
 
     async def create_card(self, card: Card) -> Card:
-        """Create a card — stub, returns empty card model."""
-        return Card()
+        """Insert a card into the database."""
+        assert self._conn is not None, "Database not connected"
+        await self._conn.execute(
+            "INSERT INTO cards (id, title, list_id, position) VALUES (?, ?, ?, ?)",
+            (card.id, card.title, card.list_id, card.position),
+        )
+        await self._conn.commit()
+        return card
 
     async def get_card(self, card_id: str) -> Card | None:
-        """Get a card by ID — stub, returns None."""
-        return None
+        """Retrieve a card by ID, or None if not found."""
+        assert self._conn is not None, "Database not connected"
+        cursor = await self._conn.execute(
+            "SELECT id, title, list_id, position FROM cards WHERE id = ?", (card_id,)
+        )
+        row = await cursor.fetchone()
+        if row is None:
+            return None
+        return Card(id=row[0], title=row[1], list_id=row[2], position=row[3])
 
     async def get_cards_by_list(self, list_id: str) -> list[Card]:
-        """Get cards by list — stub, returns empty list."""
-        return []
+        """Return all cards for a list, ordered by position."""
+        assert self._conn is not None, "Database not connected"
+        cursor = await self._conn.execute(
+            "SELECT id, title, list_id, position FROM cards WHERE list_id = ? ORDER BY position",
+            (list_id,),
+        )
+        rows = await cursor.fetchall()
+        return [Card(id=row[0], title=row[1], list_id=row[2], position=row[3]) for row in rows]
 
     async def update_card(
         self,
@@ -98,9 +233,32 @@ class Database:
         position: int | None = None,
         list_id: str | None = None,
     ) -> Card | None:
-        """Update a card — stub, returns None."""
-        return None
+        """Update a card's title, position, and/or list_id. Returns updated card or None."""
+        assert self._conn is not None, "Database not connected"
+        updates: list[str] = []
+        params: list[str | int] = []
+        if title is not None:
+            updates.append("title = ?")
+            params.append(title)
+        if position is not None:
+            updates.append("position = ?")
+            params.append(position)
+        if list_id is not None:
+            updates.append("list_id = ?")
+            params.append(list_id)
+        if not updates:
+            return await self.get_card(card_id)
+        params.append(card_id)
+        query = f"UPDATE cards SET {', '.join(updates)} WHERE id = ?"  # noqa: S608
+        cursor = await self._conn.execute(query, params)
+        await self._conn.commit()
+        if cursor.rowcount == 0:
+            return None
+        return await self.get_card(card_id)
 
     async def delete_card(self, card_id: str) -> bool:
-        """Delete a card — stub, returns False."""
-        return False
+        """Delete a card by ID. Returns True if deleted, False if not found."""
+        assert self._conn is not None, "Database not connected"
+        cursor = await self._conn.execute("DELETE FROM cards WHERE id = ?", (card_id,))
+        await self._conn.commit()
+        return cursor.rowcount > 0

--- a/backend/src/app/models.py
+++ b/backend/src/app/models.py
@@ -1,0 +1,32 @@
+"""Data models for the Trello clone backend.
+
+Stub module — implementation pending (TRE-31).
+Models are importable but not yet implemented with correct behavior.
+"""
+
+from pydantic import BaseModel
+
+
+class Board(BaseModel):
+    """Board model stub — fields and validation not yet implemented."""
+
+    id: str = ""
+    title: str = ""
+
+
+class List(BaseModel):
+    """List model stub — fields and validation not yet implemented."""
+
+    id: str = ""
+    title: str = ""
+    board_id: str = ""
+    position: int = -1
+
+
+class Card(BaseModel):
+    """Card model stub — fields and validation not yet implemented."""
+
+    id: str = ""
+    title: str = ""
+    list_id: str = ""
+    position: int = -1

--- a/backend/src/app/models.py
+++ b/backend/src/app/models.py
@@ -1,32 +1,46 @@
 """Data models for the Trello clone backend.
 
-Stub module — implementation pending (TRE-31).
-Models are importable but not yet implemented with correct behavior.
+Defines Board, List, and Card Pydantic models with validation and immutability.
 """
 
-from pydantic import BaseModel
+from __future__ import annotations
+
+import uuid
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+def _uuid4_str() -> str:
+    """Generate a UUID v4 string."""
+    return str(uuid.uuid4())
 
 
 class Board(BaseModel):
-    """Board model stub — fields and validation not yet implemented."""
+    """A Trello-style board containing lists."""
 
-    id: str = ""
-    title: str = ""
+    model_config = ConfigDict(frozen=True)
+
+    id: str = Field(default_factory=_uuid4_str)
+    title: str = Field(min_length=1)
 
 
 class List(BaseModel):
-    """List model stub — fields and validation not yet implemented."""
+    """A list within a board, containing cards. Ordered by position."""
 
-    id: str = ""
-    title: str = ""
-    board_id: str = ""
-    position: int = -1
+    model_config = ConfigDict(frozen=True)
+
+    id: str = Field(default_factory=_uuid4_str)
+    title: str = Field(min_length=1)
+    board_id: str
+    position: int = 0
 
 
 class Card(BaseModel):
-    """Card model stub — fields and validation not yet implemented."""
+    """A card within a list. Ordered by position."""
 
-    id: str = ""
-    title: str = ""
-    list_id: str = ""
-    position: int = -1
+    model_config = ConfigDict(frozen=True)
+
+    id: str = Field(default_factory=_uuid4_str)
+    title: str = Field(min_length=1)
+    list_id: str
+    position: int = 0

--- a/backend/tests/test_database.py
+++ b/backend/tests/test_database.py
@@ -1,0 +1,325 @@
+"""Unit tests for SQLite persistence layer (Database CRUD operations).
+
+Verifies schema creation, seed logic, and full CRUD for Board, List, and Card entities.
+Uses in-memory SQLite for isolation and speed.
+These tests correspond to the feedback loop plan in docs/feedback-loops/TRE-31-feedback.md.
+"""
+
+import uuid
+
+import pytest
+
+from app.database import Database
+from app.models import Board, Card, List
+
+
+@pytest.fixture
+async def db() -> Database:  # type: ignore[misc]
+    """Create an in-memory Database instance with schema initialized."""
+    database = Database(":memory:")
+    await database.connect()
+    await database.init_schema()
+    yield database  # type: ignore[misc]
+    await database.close()
+
+
+class TestSchema:
+    """Tests for schema initialization."""
+
+    async def test_schema_creates_tables(self, db: Database) -> None:
+        """After init_schema, querying sqlite_master returns boards, lists, cards tables."""
+        # The db fixture already called init_schema; we verify the tables exist.
+        # We need to access the internal connection to query sqlite_master.
+        assert db._conn is not None, "Database connection should be established"
+        cursor = await db._conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name"
+        )
+        rows = await cursor.fetchall()
+        table_names = sorted(row[0] for row in rows)
+        assert "boards" in table_names, "boards table should exist"
+        assert "cards" in table_names, "cards table should exist"
+        assert "lists" in table_names, "lists table should exist"
+
+
+class TestSeedDefaultBoard:
+    """Tests for default board seeding."""
+
+    async def test_seed_default_board_creates_board(self, db: Database) -> None:
+        """seed_default_board inserts one board titled 'My Board' when DB is empty."""
+        board = await db.seed_default_board()
+        assert board.title == "My Board", "Default board should be titled 'My Board'"
+        assert board.id is not None, "Default board should have an id"
+        # Verify it's in the database
+        boards = await db.list_boards()
+        assert len(boards) == 1, "Should have exactly one board after seeding"
+
+    async def test_seed_default_board_idempotent(self, db: Database) -> None:
+        """Calling seed_default_board twice returns same board; list_boards returns exactly 1."""
+        board1 = await db.seed_default_board()
+        board2 = await db.seed_default_board()
+        assert board1.id == board2.id, "Seed should return the same board on second call"
+        boards = await db.list_boards()
+        assert len(boards) == 1, "Should still have exactly one board after double seed"
+
+
+class TestBoardCRUD:
+    """Tests for Board CRUD operations."""
+
+    async def test_create_board(self, db: Database) -> None:
+        """create_board inserts a board; get_board retrieves it with matching fields."""
+        board = Board(title="Project Alpha")
+        created = await db.create_board(board)
+        assert created.id == board.id, "Created board should have the same id"
+        assert created.title == "Project Alpha"
+
+        retrieved = await db.get_board(board.id)
+        assert retrieved is not None, "get_board should find the created board"
+        assert retrieved.id == board.id
+        assert retrieved.title == "Project Alpha"
+
+    async def test_get_board_not_found(self, db: Database) -> None:
+        """get_board with non-existent ID returns None."""
+        result = await db.get_board(str(uuid.uuid4()))
+        assert result is None, "get_board should return None for non-existent ID"
+
+    async def test_list_boards(self, db: Database) -> None:
+        """After creating 3 boards, list_boards returns all 3."""
+        for i in range(3):
+            await db.create_board(Board(title=f"Board {i}"))
+        boards = await db.list_boards()
+        assert len(boards) == 3, "list_boards should return all 3 created boards"
+
+    async def test_update_board(self, db: Database) -> None:
+        """update_board changes title; subsequent get_board reflects the change."""
+        board = Board(title="Old Title")
+        await db.create_board(board)
+        updated = await db.update_board(board.id, title="New Title")
+        assert updated is not None, "update_board should return the updated board"
+        assert updated.title == "New Title", "Title should be updated"
+
+        retrieved = await db.get_board(board.id)
+        assert retrieved is not None
+        assert retrieved.title == "New Title"
+
+    async def test_update_board_not_found(self, db: Database) -> None:
+        """update_board with non-existent ID returns None."""
+        result = await db.update_board(str(uuid.uuid4()), title="Nope")
+        assert result is None, "update_board should return None for non-existent ID"
+
+    async def test_delete_board(self, db: Database) -> None:
+        """delete_board returns True; subsequent get_board returns None."""
+        board = Board(title="To Delete")
+        await db.create_board(board)
+        deleted = await db.delete_board(board.id)
+        assert deleted is True, "delete_board should return True for existing board"
+
+        retrieved = await db.get_board(board.id)
+        assert retrieved is None, "get_board should return None after deletion"
+
+    async def test_delete_board_not_found(self, db: Database) -> None:
+        """delete_board with non-existent ID returns False."""
+        result = await db.delete_board(str(uuid.uuid4()))
+        assert result is False, "delete_board should return False for non-existent ID"
+
+
+class TestListCRUD:
+    """Tests for List CRUD operations."""
+
+    async def test_create_list(self, db: Database) -> None:
+        """create_list inserts a list; get_list retrieves it."""
+        board = Board(title="Board")
+        await db.create_board(board)
+        lst = List(title="To Do", board_id=board.id)
+        created = await db.create_list(lst)
+        assert created.id == lst.id
+        assert created.title == "To Do"
+
+        retrieved = await db.get_list(lst.id)
+        assert retrieved is not None, "get_list should find the created list"
+        assert retrieved.title == "To Do"
+        assert retrieved.board_id == board.id
+
+    async def test_get_lists_by_board_ordered(self, db: Database) -> None:
+        """Lists for a board are returned ordered by position."""
+        board = Board(title="Board")
+        await db.create_board(board)
+        # Create lists out of order
+        await db.create_list(List(title="Third", board_id=board.id, position=2))
+        await db.create_list(List(title="First", board_id=board.id, position=0))
+        await db.create_list(List(title="Second", board_id=board.id, position=1))
+
+        lists = await db.get_lists_by_board(board.id)
+        assert len(lists) == 3, "Should have 3 lists"
+        assert lists[0].title == "First", "Lists should be ordered by position"
+        assert lists[1].title == "Second"
+        assert lists[2].title == "Third"
+
+    async def test_update_list_title(self, db: Database) -> None:
+        """update_list with new title updates the record."""
+        board = Board(title="Board")
+        await db.create_board(board)
+        lst = List(title="Old Title", board_id=board.id)
+        await db.create_list(lst)
+
+        updated = await db.update_list(lst.id, title="New Title")
+        assert updated is not None
+        assert updated.title == "New Title", "Title should be updated"
+
+    async def test_update_list_position(self, db: Database) -> None:
+        """update_list with new position updates the record."""
+        board = Board(title="Board")
+        await db.create_board(board)
+        lst = List(title="Movable", board_id=board.id, position=0)
+        await db.create_list(lst)
+
+        updated = await db.update_list(lst.id, position=5)
+        assert updated is not None
+        assert updated.position == 5, "Position should be updated"
+
+    async def test_delete_list(self, db: Database) -> None:
+        """delete_list returns True; subsequent get_list returns None."""
+        board = Board(title="Board")
+        await db.create_board(board)
+        lst = List(title="To Delete", board_id=board.id)
+        await db.create_list(lst)
+
+        deleted = await db.delete_list(lst.id)
+        assert deleted is True, "delete_list should return True for existing list"
+
+        retrieved = await db.get_list(lst.id)
+        assert retrieved is None, "get_list should return None after deletion"
+
+
+class TestCardCRUD:
+    """Tests for Card CRUD operations."""
+
+    async def test_create_card(self, db: Database) -> None:
+        """create_card inserts a card; get_card retrieves it."""
+        board = Board(title="Board")
+        await db.create_board(board)
+        lst = List(title="To Do", board_id=board.id)
+        await db.create_list(lst)
+        card = Card(title="My Task", list_id=lst.id)
+        created = await db.create_card(card)
+        assert created.id == card.id
+        assert created.title == "My Task"
+
+        retrieved = await db.get_card(card.id)
+        assert retrieved is not None, "get_card should find the created card"
+        assert retrieved.title == "My Task"
+        assert retrieved.list_id == lst.id
+
+    async def test_get_cards_by_list_ordered(self, db: Database) -> None:
+        """Cards for a list are returned ordered by position."""
+        board = Board(title="Board")
+        await db.create_board(board)
+        lst = List(title="To Do", board_id=board.id)
+        await db.create_list(lst)
+        # Create cards out of order
+        await db.create_card(Card(title="Third", list_id=lst.id, position=2))
+        await db.create_card(Card(title="First", list_id=lst.id, position=0))
+        await db.create_card(Card(title="Second", list_id=lst.id, position=1))
+
+        cards = await db.get_cards_by_list(lst.id)
+        assert len(cards) == 3, "Should have 3 cards"
+        assert cards[0].title == "First", "Cards should be ordered by position"
+        assert cards[1].title == "Second"
+        assert cards[2].title == "Third"
+
+    async def test_update_card_title(self, db: Database) -> None:
+        """update_card with new title updates the record."""
+        board = Board(title="Board")
+        await db.create_board(board)
+        lst = List(title="To Do", board_id=board.id)
+        await db.create_list(lst)
+        card = Card(title="Old Title", list_id=lst.id)
+        await db.create_card(card)
+
+        updated = await db.update_card(card.id, title="New Title")
+        assert updated is not None
+        assert updated.title == "New Title", "Card title should be updated"
+
+    async def test_update_card_position(self, db: Database) -> None:
+        """update_card with new position updates the record."""
+        board = Board(title="Board")
+        await db.create_board(board)
+        lst = List(title="To Do", board_id=board.id)
+        await db.create_list(lst)
+        card = Card(title="Movable", list_id=lst.id, position=0)
+        await db.create_card(card)
+
+        updated = await db.update_card(card.id, position=7)
+        assert updated is not None
+        assert updated.position == 7, "Card position should be updated"
+
+    async def test_update_card_move_to_list(self, db: Database) -> None:
+        """update_card with new list_id moves card between lists."""
+        board = Board(title="Board")
+        await db.create_board(board)
+        lst1 = List(title="To Do", board_id=board.id, position=0)
+        lst2 = List(title="Done", board_id=board.id, position=1)
+        await db.create_list(lst1)
+        await db.create_list(lst2)
+        card = Card(title="Moving Card", list_id=lst1.id)
+        await db.create_card(card)
+
+        updated = await db.update_card(card.id, list_id=lst2.id)
+        assert updated is not None
+        assert updated.list_id == lst2.id, "Card should be moved to the new list"
+
+        # Verify the card is no longer in the old list
+        old_list_cards = await db.get_cards_by_list(lst1.id)
+        assert len(old_list_cards) == 0, "Old list should have no cards"
+        new_list_cards = await db.get_cards_by_list(lst2.id)
+        assert len(new_list_cards) == 1, "New list should have the moved card"
+
+    async def test_delete_card(self, db: Database) -> None:
+        """delete_card returns True; subsequent get_card returns None."""
+        board = Board(title="Board")
+        await db.create_board(board)
+        lst = List(title="To Do", board_id=board.id)
+        await db.create_list(lst)
+        card = Card(title="To Delete", list_id=lst.id)
+        await db.create_card(card)
+
+        deleted = await db.delete_card(card.id)
+        assert deleted is True, "delete_card should return True for existing card"
+
+        retrieved = await db.get_card(card.id)
+        assert retrieved is None, "get_card should return None after deletion"
+
+
+class TestCascadeDelete:
+    """Tests for cascade/referential integrity behavior."""
+
+    async def test_delete_board_cascades(self, db: Database) -> None:
+        """Deleting a board also removes its lists and cards (CASCADE)."""
+        board = Board(title="Cascade Board")
+        await db.create_board(board)
+        lst = List(title="Cascade List", board_id=board.id)
+        await db.create_list(lst)
+        card = Card(title="Cascade Card", list_id=lst.id)
+        await db.create_card(card)
+
+        deleted = await db.delete_board(board.id)
+        assert deleted is True
+
+        # Lists and cards should also be gone
+        assert await db.get_list(lst.id) is None, "List should be deleted with board"
+        assert await db.get_card(card.id) is None, "Card should be deleted with board"
+
+    async def test_delete_list_cascades_cards(self, db: Database) -> None:
+        """Deleting a list also removes its cards (CASCADE)."""
+        board = Board(title="Board")
+        await db.create_board(board)
+        lst = List(title="Cascade List", board_id=board.id)
+        await db.create_list(lst)
+        card = Card(title="Cascade Card", list_id=lst.id)
+        await db.create_card(card)
+
+        deleted = await db.delete_list(lst.id)
+        assert deleted is True
+
+        # Card should be gone, but board should remain
+        assert await db.get_card(card.id) is None, "Card should be deleted with list"
+        assert await db.get_board(board.id) is not None, "Board should still exist"

--- a/backend/tests/test_models.py
+++ b/backend/tests/test_models.py
@@ -1,0 +1,122 @@
+"""Unit tests for Pydantic data models (Board, List, Card).
+
+Verifies model creation, defaults, validation constraints, and immutability.
+These tests correspond to the feedback loop plan in docs/feedback-loops/TRE-31-feedback.md.
+"""
+
+import uuid
+
+import pytest
+from pydantic import ValidationError
+
+from app.models import Board, Card, List
+
+
+class TestBoard:
+    """Tests for the Board model."""
+
+    def test_board_creation_defaults(self) -> None:
+        """Board created with only `title` has auto-generated UUID `id`."""
+        board = Board(title="Test Board")
+        # id should be a non-empty, valid UUID v4 string
+        assert board.id, "Board id should not be empty"
+        try:
+            parsed = uuid.UUID(board.id)
+        except ValueError:
+            pytest.fail(f"Board id {board.id!r} is not a valid UUID string")
+        assert parsed.version == 4, "Board id should be a UUID v4"
+        assert board.title == "Test Board"
+
+    def test_board_creation_explicit_id(self) -> None:
+        """Board created with explicit `id` and `title` preserves both."""
+        explicit_id = str(uuid.uuid4())
+        board = Board(id=explicit_id, title="My Board")
+        assert board.id == explicit_id, "Board should preserve explicit id"
+        assert board.title == "My Board", "Board should preserve explicit title"
+
+    def test_board_rejects_empty_title(self) -> None:
+        """ValidationError raised when `title` is empty string."""
+        with pytest.raises(ValidationError, match="title"):
+            Board(title="")
+
+    def test_board_immutable(self) -> None:
+        """Assigning to `board.title` raises ValidationError (frozen model)."""
+        board = Board(title="Immutable Board")
+        with pytest.raises(ValidationError):
+            board.title = "Changed"  # type: ignore[misc]
+
+
+class TestList:
+    """Tests for the List model."""
+
+    def test_list_creation_defaults(self) -> None:
+        """List created with `title` and `board_id` has `position=0` and auto UUID."""
+        board_id = str(uuid.uuid4())
+        lst = List(title="To Do", board_id=board_id)
+        # id should be a non-empty, valid UUID v4 string
+        assert lst.id, "List id should not be empty"
+        try:
+            parsed = uuid.UUID(lst.id)
+        except ValueError:
+            pytest.fail(f"List id {lst.id!r} is not a valid UUID string")
+        assert parsed.version == 4, "List id should be a UUID v4"
+        assert lst.title == "To Do"
+        assert lst.board_id == board_id
+        assert lst.position == 0, "List position should default to 0"
+
+    def test_list_creation_explicit_position(self) -> None:
+        """List with explicit `position=5` preserves the value."""
+        board_id = str(uuid.uuid4())
+        lst = List(title="Done", board_id=board_id, position=5)
+        assert lst.position == 5, "List should preserve explicit position"
+
+    def test_list_rejects_empty_title(self) -> None:
+        """ValidationError raised when `title` is empty string."""
+        board_id = str(uuid.uuid4())
+        with pytest.raises(ValidationError, match="title"):
+            List(title="", board_id=board_id)
+
+    def test_list_immutable(self) -> None:
+        """Assigning to `lst.position` raises ValidationError (frozen model)."""
+        board_id = str(uuid.uuid4())
+        lst = List(title="In Progress", board_id=board_id)
+        with pytest.raises(ValidationError):
+            lst.position = 99  # type: ignore[misc]
+
+
+class TestCard:
+    """Tests for the Card model."""
+
+    def test_card_creation_defaults(self) -> None:
+        """Card created with `title` and `list_id` has `position=0` and auto UUID."""
+        list_id = str(uuid.uuid4())
+        card = Card(title="My Task", list_id=list_id)
+        # id should be a non-empty, valid UUID v4 string
+        assert card.id, "Card id should not be empty"
+        try:
+            parsed = uuid.UUID(card.id)
+        except ValueError:
+            pytest.fail(f"Card id {card.id!r} is not a valid UUID string")
+        assert parsed.version == 4, "Card id should be a UUID v4"
+        assert card.title == "My Task"
+        assert card.list_id == list_id
+        assert card.position == 0, "Card position should default to 0"
+
+    def test_card_creation_explicit_position(self) -> None:
+        """Card with explicit `position=3` preserves the value."""
+        list_id = str(uuid.uuid4())
+        card = Card(title="Another Task", list_id=list_id, position=3)
+        assert card.position == 3, "Card should preserve explicit position"
+
+    def test_card_rejects_empty_title(self) -> None:
+        """ValidationError raised when `title` is empty string."""
+        list_id = str(uuid.uuid4())
+        with pytest.raises(ValidationError, match="title"):
+            Card(title="", list_id=list_id)
+
+    def test_card_immutable(self) -> None:
+        """Assigning to `card.title` raises ValidationError (frozen model)."""
+        list_id = str(uuid.uuid4())
+        card = Card(title="Frozen Card", list_id=list_id)
+        with pytest.raises(ValidationError):
+            card.title = "Changed"  # type: ignore[misc]

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -3,6 +3,15 @@ revision = 3
 requires-python = ">=3.12"
 
 [[package]]
+name = "aiosqlite"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/8a/64761f4005f17809769d23e518d915db74e6310474e733e3593cfc854ef1/aiosqlite-0.22.1.tar.gz", hash = "sha256:043e0bd78d32888c0a9ca90fc788b38796843360c855a7262a532813133a0650", size = 14821, upload-time = "2025-12-23T19:25:43.997Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/b7/e3bf5133d697a08128598c8d0abc5e16377b51465a33756de24fa7dee953/aiosqlite-0.22.1-py3-none-any.whl", hash = "sha256:21c002eb13823fad740196c5a2e9d8e62f6243bd9e7e4a1f87fb5e44ecb4fceb", size = 17405, upload-time = "2025-12-23T19:25:42.139Z" },
+]
+
+[[package]]
 name = "annotated-doc"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -606,6 +615,7 @@ name = "trello-clone-backend"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "aiosqlite" },
     { name = "fastapi" },
     { name = "structlog" },
     { name = "uvicorn", extra = ["standard"] },
@@ -623,6 +633,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "aiosqlite", specifier = ">=0.20.0" },
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.13.0" },

--- a/docs/agents/implementation.md
+++ b/docs/agents/implementation.md
@@ -44,3 +44,11 @@
 - Config: `backend/src/app/logging.py`
 - Import: `from app.logging import get_logger, setup_logging`
 - Format: JSON to stdout
+
+### Database
+- **Engine:** SQLite via `aiosqlite`
+- **Module:** `backend/src/app/database.py` — `Database` class with async lifecycle
+- **Models:** `backend/src/app/models.py` — frozen Pydantic `BaseModel` subclasses (no ORM)
+- **Pattern:** The `Database` class owns the connection and provides async CRUD methods. Call `connect()` → `init_schema()` → `seed_default_board()` on startup; `close()` on shutdown.
+- **Adding entities:** Define a Pydantic model in `models.py`, add `CREATE TABLE` SQL to `init_schema()`, then add CRUD methods to `Database` following the existing Board/List/Card pattern.
+- **ADR:** See `docs/architecture/adr-001-sqlite-persistence.md` for rationale.

--- a/docs/architecture/adr-001-sqlite-persistence.md
+++ b/docs/architecture/adr-001-sqlite-persistence.md
@@ -1,0 +1,51 @@
+# ADR-001: SQLite Persistence with Decoupled Pydantic Models
+
+**Date:** 2026-03-19
+**Status:** Accepted
+
+## Context
+
+TRE-31 introduces the first persistence layer for the Trello clone backend. The application needs to store Board, List, and Card entities with positional ordering. Key forces at play:
+
+- The v0 scope is a single-board application — no multi-tenant or high-concurrency requirements yet.
+- The team wants zero-config local development (no external database server).
+- The backend uses FastAPI with async request handling, so the persistence layer must support async operations.
+- Data models need to be usable independently of the storage mechanism for testing and future flexibility.
+
+## Decision
+
+### 1. SQLite via aiosqlite as the persistence backend
+
+We chose SQLite (via the `aiosqlite` library) for the v0 data store. The database file lives at `data/trello.db` by default and is configurable via the `Database` constructor. WAL mode and foreign key enforcement are enabled on every connection (`backend/src/app/database.py:31-32`).
+
+### 2. Pydantic models decoupled from the database layer
+
+Data models (`Board`, `List`, `Card`) are defined as pure frozen Pydantic `BaseModel` subclasses in `backend/src/app/models.py`. They have no awareness of SQLite or any ORM. The `Database` class in `backend/src/app/database.py` manually maps between Pydantic models and SQL rows.
+
+### 3. Schema initialization and default board seeding
+
+Tables are created via `Database.init_schema()` using `CREATE TABLE IF NOT EXISTS`, making it idempotent. A default board is seeded via `Database.seed_default_board()`, which is also idempotent (skips if any board exists).
+
+## Consequences
+
+### Positive
+- Zero external dependencies for storage — no database server to install or configure
+- Async-compatible via `aiosqlite`, integrating cleanly with FastAPI's async handlers
+- Pydantic models can be tested in isolation without any database
+- Schema is self-initializing — no migration tool needed for v0
+- WAL mode provides reasonable read concurrency for the single-board use case
+
+### Negative
+- SQLite does not support concurrent writes from multiple processes — will need migration if the application scales beyond a single instance
+- No migration framework — schema changes require manual `ALTER TABLE` or a future adoption of Alembic or similar
+- Manual SQL-to-model mapping in the `Database` class is repetitive and must be maintained in sync with models
+
+### Neutral
+- The `data/` directory must be persisted across deployments (relevant for Docker volumes and production deploy)
+- Foreign keys with `ON DELETE CASCADE` handle referential integrity automatically
+
+## Alternatives Considered
+
+- **PostgreSQL:** Rejected for v0 — adds operational complexity (server management, connection pooling) that is unnecessary for a single-board MVP. Can be adopted later without changing the Pydantic models.
+- **SQLAlchemy ORM:** Rejected — introduces a heavy abstraction layer not justified at this scale. The current manual mapping is ~100 lines and easy to understand. ORM would also couple models to the database layer, reducing testability.
+- **In-memory dict store:** Rejected — no persistence across restarts, no relational integrity guarantees. Would need to be replaced immediately for any production use.

--- a/docs/feedback-loops/TRE-31-feedback.md
+++ b/docs/feedback-loops/TRE-31-feedback.md
@@ -1,0 +1,169 @@
+# Feedback Loop Plan: TRE-31
+
+## Overview
+
+Verification strategy for the backend data models and persistence layer. Covers unit tests for Pydantic models, unit tests for database CRUD operations, runtime validation via structured logging, and observability hooks for production monitoring.
+
+---
+
+## 1. Unit Tests — Models (`backend/tests/test_models.py`)
+
+These tests verify Pydantic model validation, defaults, constraints, and immutability.
+
+### Test Cases
+
+| Test Name | Expected Behavior |
+|---|---|
+| `test_board_creation_defaults` | Board created with only `title` has auto-generated UUID `id` |
+| `test_board_creation_explicit_id` | Board created with explicit `id` and `title` preserves both |
+| `test_board_rejects_empty_title` | `ValidationError` raised when `title` is empty string |
+| `test_board_immutable` | Assigning to `board.title` raises `ValidationError` (frozen model) |
+| `test_list_creation_defaults` | List created with `title` and `board_id` has `position=0` and auto UUID |
+| `test_list_creation_explicit_position` | List with explicit `position=5` preserves the value |
+| `test_list_rejects_empty_title` | `ValidationError` raised when `title` is empty string |
+| `test_list_immutable` | Assigning to `lst.position` raises `ValidationError` |
+| `test_card_creation_defaults` | Card created with `title` and `list_id` has `position=0` and auto UUID |
+| `test_card_creation_explicit_position` | Card with explicit `position=3` preserves the value |
+| `test_card_rejects_empty_title` | `ValidationError` raised when `title` is empty string |
+| `test_card_immutable` | Assigning to `card.title` raises `ValidationError` |
+
+### Run Command
+
+```bash
+cd backend && uv run pytest tests/test_models.py -v
+```
+
+---
+
+## 2. Unit Tests — Database CRUD (`backend/tests/test_database.py`)
+
+These tests verify the SQLite persistence layer using in-memory databases for isolation and speed.
+
+### Fixture
+
+```python
+@pytest.fixture
+async def db():
+    database = Database(":memory:")
+    await database.connect()
+    await database.init_schema()
+    yield database
+    await database.close()
+```
+
+### Test Cases
+
+| Test Name | Expected Behavior |
+|---|---|
+| `test_schema_creates_tables` | After `init_schema`, querying `sqlite_master` returns `boards`, `lists`, `cards` tables |
+| `test_seed_default_board_creates_board` | `seed_default_board` inserts one board titled "My Board" when DB is empty |
+| `test_seed_default_board_idempotent` | Calling `seed_default_board` twice returns same board; `list_boards` returns exactly 1 |
+| `test_create_board` | `create_board` inserts a board; `get_board` retrieves it with matching fields |
+| `test_get_board_not_found` | `get_board` with non-existent ID returns `None` |
+| `test_list_boards` | After creating 3 boards, `list_boards` returns all 3 |
+| `test_update_board` | `update_board` changes title; subsequent `get_board` reflects the change |
+| `test_update_board_not_found` | `update_board` with non-existent ID returns `None` |
+| `test_delete_board` | `delete_board` returns `True`; subsequent `get_board` returns `None` |
+| `test_delete_board_not_found` | `delete_board` with non-existent ID returns `False` |
+| `test_create_list` | `create_list` inserts a list; `get_list` retrieves it |
+| `test_get_lists_by_board_ordered` | Lists for a board are returned ordered by `position` |
+| `test_update_list_title` | `update_list` with new title updates the record |
+| `test_update_list_position` | `update_list` with new position updates the record |
+| `test_delete_list` | `delete_list` returns `True`; subsequent `get_list` returns `None` |
+| `test_create_card` | `create_card` inserts a card; `get_card` retrieves it |
+| `test_get_cards_by_list_ordered` | Cards for a list are returned ordered by `position` |
+| `test_update_card_title` | `update_card` with new title updates the record |
+| `test_update_card_position` | `update_card` with new position updates the record |
+| `test_update_card_move_to_list` | `update_card` with new `list_id` moves card between lists |
+| `test_delete_card` | `delete_card` returns `True`; subsequent `get_card` returns `None` |
+| `test_delete_board_cascades` | Deleting a board also removes its lists and cards (CASCADE) |
+| `test_delete_list_cascades_cards` | Deleting a list also removes its cards (CASCADE) |
+
+### Run Command
+
+```bash
+cd backend && uv run pytest tests/test_database.py -v
+```
+
+---
+
+## 3. Full Test Suite
+
+Run all tests to verify no regressions against the existing smoke test:
+
+```bash
+cd backend && uv run pytest -v
+```
+
+---
+
+## 4. Static Analysis
+
+### Type Checking
+
+```bash
+cd backend && uv run mypy src/app/models.py src/app/database.py --strict
+```
+
+Verifies:
+- All functions have type annotations
+- No `Any` types leak through
+- aiosqlite usage is type-safe (or explicitly ignored where stubs are incomplete)
+
+### Linting
+
+```bash
+cd backend && uv run ruff check src/app/models.py src/app/database.py
+```
+
+Verifies:
+- Code follows project style (line length 100, Python 3.12 target)
+- No import ordering issues
+- No unused imports or variables
+
+---
+
+## 5. Observability Hooks
+
+The persistence layer includes structured logging via `structlog` for runtime observability:
+
+| Event | Log Level | Fields | Purpose |
+|---|---|---|---|
+| `database_connected` | `info` | `db_path` | Confirms DB connection established |
+| `database_closed` | `info` | `db_path` | Confirms DB connection closed |
+| `schema_initialized` | `info` | `tables_created` | Confirms tables exist after init |
+| `default_board_seeded` | `info` | `board_id`, `board_title` | Confirms default board created on first run |
+| `default_board_exists` | `debug` | `board_id` | Default board already present, seed skipped |
+| CRUD operations | `debug` | `entity_type`, `entity_id`, `operation` | Trace individual persistence operations |
+
+These log events allow operators to:
+- Verify the database initializes correctly on first deployment
+- Trace data operations in development/staging
+- Debug persistence issues without adding ad-hoc print statements
+
+---
+
+## 6. Runtime Validation
+
+- **Schema verification:** `init_schema()` uses `CREATE TABLE IF NOT EXISTS`, making it safe to call on every startup without data loss. The method should query `sqlite_master` after creation and log the result to confirm tables exist.
+- **Foreign key enforcement:** `PRAGMA foreign_keys = ON` is executed on every connection open. This prevents orphaned records at the database level.
+- **Seed idempotency:** `seed_default_board()` checks for existing boards before inserting, preventing duplicate default boards across restarts.
+- **Parameterized queries:** All SQL uses `?` placeholders, preventing SQL injection at the boundary between application code and database.
+
+---
+
+## Feedback Completeness Score
+
+| Dimension | Score (0-2) | Justification |
+|---|---|---|
+| Unit tests — models | 2 | 12 test cases covering creation, defaults, validation errors, and immutability |
+| Unit tests — persistence | 2 | 23 test cases covering full CRUD for all 3 entities plus schema, seed, cascade |
+| Static analysis | 1 | mypy strict + ruff linting verify type safety and style |
+| Observability | 1 | Structured logging for lifecycle events and CRUD operations |
+| Runtime validation | 1 | Schema verification, FK enforcement, seed idempotency, parameterized queries |
+| Integration tests | 0 | Not applicable — no API endpoints yet; persistence is tested in isolation |
+| E2e tests | 0 | Not applicable — no user-facing interface in this issue |
+
+**Total feedback_completeness_score: 7/10**
+
+The score of 7 exceeds the minimum threshold of 6. Integration and e2e tests are not applicable because this issue only introduces the internal persistence layer with no API surface. Those verification layers will be added when the API endpoints issue (future) is implemented.

--- a/docs/plans/TRE-31-doc-impact.md
+++ b/docs/plans/TRE-31-doc-impact.md
@@ -1,0 +1,71 @@
+# Doc Impact Analysis: TRE-31
+
+## Overview
+
+TRE-31 introduces the first data models and persistence layer to the backend. Since this is greenfield infrastructure with no prior database or model documentation, the documentation impact is primarily additive — new docs rather than updates to existing ones.
+
+---
+
+## Impacted Documents
+
+### 1. `CLAUDE.md` — Project Structure Section
+
+- **Impact:** LOW — Minor update
+- **Reason:** The Project Structure section (lines 75-101) may need to reflect the new `models.py` and `database.py` files if the team wants the map to reference the data layer. However, CLAUDE.md is meant to be a high-level map (Principle 1: under 120 lines), so individual source files should NOT be listed. No change needed unless the team decides to add a "Backend Architecture" subsection.
+- **Action:** No change required. The existing structure already covers `backend/` implicitly.
+
+### 2. `docs/architecture/` — New ADR Recommended
+
+- **Impact:** MEDIUM — New ADR recommended
+- **Reason:** This issue makes two architectural decisions that should be documented per Principle 6 (Document Decisions, Not Descriptions):
+  1. **SQLite with aiosqlite** as the persistence backend (vs. PostgreSQL, in-memory stores, etc.)
+  2. **Pydantic models separate from ORM** — the models are pure Pydantic, not SQLAlchemy/ORM models; the database layer manually maps between models and SQL.
+- **Action:** The Docs Agent should create `docs/architecture/adr-001-sqlite-persistence.md` documenting:
+  - Why SQLite was chosen for v0 (simplicity, zero-config, single-board scope)
+  - Why Pydantic models are decoupled from the database layer (flexibility, testability)
+  - Trade-offs acknowledged (no concurrent write scaling, no migration framework yet)
+
+### 3. `docs/agents/implementation.md` — Backend Patterns
+
+- **Impact:** LOW — Optional update
+- **Reason:** The implementation agent context doc may benefit from noting the database module pattern (class-based Database with async connect/close lifecycle) so future implementation agents follow the same pattern when adding new entities or CRUD operations.
+- **Action:** If the doc is currently a placeholder, defer to when more patterns are established. If it has content, add a note about the `Database` class pattern.
+
+### 4. `docs/runbooks/deploy-prod.md` — Database File Location
+
+- **Impact:** LOW — Future concern
+- **Reason:** The persistence layer introduces a SQLite database file that needs to be persisted across deployments. The deploy runbook should eventually document where the `.db` file lives and how it's backed up. However, this is a v0 concern — the current Dockerfile and deploy config don't reference a database yet.
+- **Action:** Defer to the deployment/infrastructure issue. Flag for future update.
+
+### 5. `README.md` — Dependencies Section
+
+- **Impact:** LOW — Minor update
+- **Reason:** The README should reflect that `aiosqlite` is now a runtime dependency, and that the backend uses SQLite for persistence. This helps new contributors understand the tech stack.
+- **Action:** The Docs Agent should add a brief mention of SQLite/aiosqlite to any "Tech Stack" or "Dependencies" section in the README.
+
+---
+
+## Documents NOT Impacted
+
+| Document | Reason |
+|---|---|
+| `docs/conventions/golden-principles.md` | No new conventions introduced |
+| `docs/guides/workflow-customization.md` | Orca workflow unchanged |
+| `docs/agents/scoping.md` | Scoping process unchanged |
+| `docs/agents/planning.md` | Planning process unchanged |
+| `docs/agents/design-feedback-loop.md` | DFL process unchanged |
+| `docs/agents/validation.md` | Validation process unchanged |
+| `docs/agents/docs-update.md` | Docs process unchanged |
+| `frontend/` docs | No frontend changes |
+
+---
+
+## Summary
+
+| Document | Impact Level | Action |
+|---|---|---|
+| `CLAUDE.md` | None | No change needed |
+| `docs/architecture/adr-001-sqlite-persistence.md` | Medium | **Create new ADR** — SQLite choice and model/DB separation |
+| `docs/agents/implementation.md` | Low | Optional — note Database class pattern |
+| `docs/runbooks/deploy-prod.md` | Low | Defer — flag for infrastructure issue |
+| `README.md` | Low | Add aiosqlite/SQLite to tech stack description |

--- a/docs/plans/TRE-31-plan.md
+++ b/docs/plans/TRE-31-plan.md
@@ -1,0 +1,110 @@
+# Implementation Plan: TRE-31
+
+## Overview
+
+Introduce the core data layer for the Trello clone backend: three Pydantic models (Board, List, Card) with position/ordering fields and a SQLite persistence layer built on `aiosqlite`. The work adds two new source modules (`models.py`, `database.py`), one dependency change (`pyproject.toml`), and two test files. All changes are confined to `backend/` and follow existing project conventions (Python 3.12, FastAPI, structlog, strict mypy, ruff, pytest-asyncio).
+
+## Steps
+
+### Step 1: Add `aiosqlite` dependency to `backend/pyproject.toml`
+
+- **Files:** `backend/pyproject.toml`
+- **Changes:** Add `"aiosqlite>=0.20.0"` to the `dependencies` list (line 6-10). This must be a runtime dependency, not a dev dependency, because the persistence layer is part of the application.
+- **Depends on:** None
+
+### Step 2: Define Pydantic models in `backend/src/app/models.py`
+
+- **Files:** `backend/src/app/models.py` (new)
+- **Changes:**
+  - Import `pydantic.BaseModel` and `uuid` (Pydantic ships with FastAPI, no new dependency needed).
+  - Define `Board` model with fields:
+    - `id: str` — UUID string, default generated via `uuid.uuid4()`
+    - `title: str` — board title, non-empty
+  - Define `List` model with fields:
+    - `id: str` — UUID string, default generated
+    - `title: str` — list title, non-empty
+    - `board_id: str` — foreign key reference to Board
+    - `position: int` — ordering field, default `0`
+  - Define `Card` model with fields:
+    - `id: str` — UUID string, default generated
+    - `title: str` — card title, non-empty
+    - `list_id: str` — foreign key reference to List
+    - `position: int` — ordering field, default `0`
+  - Use `pydantic.Field` for constraints (e.g., `min_length=1` on title fields).
+  - All models should use `model_config = ConfigDict(frozen=True)` to enforce immutability (changes produce new instances).
+- **Depends on:** Step 1 (Pydantic is already available via FastAPI, but the dependency step should be first to keep ordering clean)
+
+### Step 3: Implement SQLite persistence layer in `backend/src/app/database.py`
+
+- **Files:** `backend/src/app/database.py` (new)
+- **Changes:**
+  - Import `aiosqlite`, `pathlib.Path`, models from `app.models`, and `structlog` logger from `app.logging`.
+  - Define a `Database` class that encapsulates all persistence operations:
+    - `__init__(self, db_path: str | Path)` — store the database file path (default: `data/trello.db` relative to project root, or configurable).
+    - `async connect(self) -> None` — open the aiosqlite connection, enable WAL mode, enable foreign keys.
+    - `async close(self) -> None` — close the connection.
+    - `async init_schema(self) -> None` — execute `CREATE TABLE IF NOT EXISTS` for `boards`, `lists`, `cards` tables with appropriate columns, types, and foreign key constraints. Use `TEXT` for UUIDs, `INTEGER` for position, and `FOREIGN KEY` references.
+    - `async seed_default_board(self) -> Board` — check if any board exists; if not, insert a default board (title: "My Board") and return it. Log the seed action.
+  - CRUD methods for Board:
+    - `async create_board(self, board: Board) -> Board`
+    - `async get_board(self, board_id: str) -> Board | None`
+    - `async list_boards(self) -> list[Board]`
+    - `async update_board(self, board_id: str, title: str) -> Board | None`
+    - `async delete_board(self, board_id: str) -> bool`
+  - CRUD methods for List:
+    - `async create_list(self, lst: List) -> List`
+    - `async get_list(self, list_id: str) -> List | None`
+    - `async get_lists_by_board(self, board_id: str) -> list[List]` — ordered by position
+    - `async update_list(self, list_id: str, title: str | None = None, position: int | None = None) -> List | None`
+    - `async delete_list(self, list_id: str) -> bool`
+  - CRUD methods for Card:
+    - `async create_card(self, card: Card) -> Card`
+    - `async get_card(self, card_id: str) -> Card | None`
+    - `async get_cards_by_list(self, list_id: str) -> list[Card]` — ordered by position
+    - `async update_card(self, card_id: str, title: str | None = None, position: int | None = None, list_id: str | None = None) -> Card | None`
+    - `async delete_card(self, card_id: str) -> bool`
+  - All CRUD methods should use parameterized queries (never string interpolation) to prevent SQL injection.
+  - Add structured logging (via `app.logging.get_logger()`) for connection lifecycle events, schema initialization, and seed operations.
+  - Use `aiosqlite.Connection` type hints properly for mypy strict mode.
+- **Depends on:** Step 2 (models must exist to type CRUD methods)
+
+### Step 4: Write unit tests for models in `backend/tests/test_models.py`
+
+- **Files:** `backend/tests/test_models.py` (new)
+- **Changes:**
+  - Test Board creation with valid title; verify `id` is auto-generated UUID.
+  - Test Board creation with explicit id.
+  - Test Board rejects empty title (validation error).
+  - Test List creation with valid fields; verify position defaults to 0.
+  - Test List creation with explicit position.
+  - Test List rejects empty title.
+  - Test Card creation with valid fields; verify position defaults to 0.
+  - Test Card creation with explicit position.
+  - Test Card rejects empty title.
+  - Test model immutability (frozen config — assignment raises error).
+- **Depends on:** Step 2 (models must be defined)
+
+### Step 5: Write unit tests for database CRUD in `backend/tests/test_database.py`
+
+- **Files:** `backend/tests/test_database.py` (new)
+- **Changes:**
+  - Use `pytest-asyncio` and an in-memory SQLite database (`:memory:`) for fast, isolated tests.
+  - Create a `db` fixture that initializes a `Database` instance with `:memory:`, calls `connect()` and `init_schema()`, yields it, then calls `close()`.
+  - Test `init_schema` creates the three tables (query `sqlite_master`).
+  - Test `seed_default_board` creates a board when none exist.
+  - Test `seed_default_board` is idempotent (calling twice returns the same board, doesn't create duplicates).
+  - Test Board CRUD: create, get, list, update, delete.
+  - Test List CRUD: create, get by id, get by board (ordered by position), update title, update position, delete.
+  - Test Card CRUD: create, get by id, get by list (ordered by position), update title, update position, update list_id (move card), delete.
+  - Test cascade or referential integrity: deleting a board should handle associated lists/cards (decide on CASCADE vs. application-level enforcement — recommend CASCADE for simplicity in v0).
+  - Test get returns None for non-existent id.
+  - Test delete returns False for non-existent id.
+- **Depends on:** Step 3 (database module must exist), Step 4 (model tests should pass first to confirm models work)
+
+## Risk Factors
+
+- **aiosqlite version compatibility** — Pin `>=0.20.0` to ensure Python 3.12 support. Mitigation: the library is mature and well-maintained; lock file (`uv.lock`) will pin the exact version after install.
+- **mypy strict mode with aiosqlite** — `aiosqlite` may not have complete type stubs. Mitigation: use inline `# type: ignore` comments sparingly where needed, or add `aiosqlite` to mypy's `[[tool.mypy.overrides]]` with `ignore_missing_imports = true`.
+- **SQLite foreign key enforcement** — SQLite does not enforce foreign keys by default. Mitigation: execute `PRAGMA foreign_keys = ON` on every connection open (included in Step 3's `connect()` method).
+- **Position field conflicts** — No uniqueness constraint on position within a list/board, allowing duplicate positions. Mitigation: acceptable for v0; the API layer (future issue) will manage position rebalancing. Document this as a known limitation.
+- **Naming collision with `List`** — Python's built-in `list` type conflicts with the `List` model name. Mitigation: use `from __future__ import annotations` to defer evaluation, and use `list[...]` (lowercase) for Python's built-in type in type hints. Consider naming the model `TaskList` instead if the collision proves problematic for imports throughout the codebase.

--- a/docs/plans/TRE-31-scope.md
+++ b/docs/plans/TRE-31-scope.md
@@ -1,0 +1,26 @@
+# Scope Report: TRE-31
+
+## Summary
+This issue introduces the foundational data layer for the Trello clone backend: three Pydantic models (Board, List, Card) with position/ordering fields, a SQLite persistence layer using aiosqlite for async CRUD operations, schema initialization on first run, a default board seed, and corresponding unit tests. The backend currently has a minimal FastAPI scaffold with only a health endpoint, structured logging, and a smoke test — no models or database code exists yet. All files are new or minor modifications to an existing config file, and the work is contained entirely within the `backend/` directory.
+
+## Affected Files
+- `backend/src/app/models.py` (new) — Pydantic models for Board (id, title), List (id, title, board_id, position), Card (id, title, list_id, position)
+- `backend/src/app/database.py` (new) — SQLite persistence layer with async support via aiosqlite; schema initialization (CREATE TABLE), CRUD operations for all three entities, and default board seeding on first startup
+- `backend/pyproject.toml` (modify) — Add `aiosqlite` to the project dependencies list
+- `backend/tests/test_models.py` (new) — Unit tests for Pydantic model validation, defaults, and constraints
+- `backend/tests/test_database.py` (new) — Unit tests for database CRUD operations (create, read, update, delete) for Board, List, and Card, plus schema initialization and default seed verification
+
+## Subsystems Involved
+- **Data Models** — New Pydantic model definitions for the core domain entities (Board, List, Card); no existing model layer exists
+- **Persistence/Database** — New SQLite database layer with async support; includes schema management and CRUD operations; no existing database infrastructure in the project
+
+## Scope Score: 6/10
+- Files: 2pt (5 files affected)
+- Subsystems: 2pt (2 subsystems: data models + persistence)
+- LOC estimate: 2pt (~200-250 lines across all files)
+- Migration: +0pt (greenfield schema initialization, no existing data to migrate)
+- API surface: +0pt (no public REST API endpoints added or modified; internal persistence layer only)
+- **Total: 6/10**
+
+## Decision: ATOMIC
+The scope score of 6 is at the atomic threshold. The work is well-defined with clear boundaries: three straightforward Pydantic models, a single-file database module with standard CRUD patterns, a minor dependency addition, and two test files. All changes are confined to the `backend/` directory within two closely related subsystems (models and persistence). There are no migrations, no API surface changes, and no cross-cutting concerns. The issue description is specific enough to implement without ambiguity. Decomposition would add overhead without meaningful benefit at this scope level.


### PR DESCRIPTION
## Summary

Implements the core data models (Board, List, Card) and SQLite persistence layer for the Trello clone backend.

- Define frozen Pydantic models with validation, UUID generation, and positional ordering
- Implement async `Database` class with aiosqlite: WAL mode, foreign keys, schema init, default board seeding
- Full CRUD operations for Board, List, and Card entities
- 36 unit tests covering models and persistence operations

**Linear Issue:** TRE-31

## Documentation Changes

- **ADR-001** (`docs/architecture/adr-001-sqlite-persistence.md`): Documents SQLite choice, decoupled Pydantic models, and trade-offs vs PostgreSQL/SQLAlchemy/in-memory alternatives
- **Implementation context** (`docs/agents/implementation.md`): Added Database class pattern, lifecycle, and guide for adding new entities
- **README** (`README.md`): Added tech stack table and getting started commands

## Doc Impact Checklist (TRE-31)

| Document | Impact | Status |
|----------|--------|--------|
| `CLAUDE.md` | None | No change needed |
| `docs/architecture/adr-001-sqlite-persistence.md` | Medium | Created |
| `docs/agents/implementation.md` | Low | Updated |
| `docs/runbooks/deploy-prod.md` | Low | Deferred (infrastructure issue) |
| `README.md` | Low | Updated |

## Validation

- All 4 CI checks passed (Test, Lint & Format, Deploy PR Preview, E2E Tests)
- Doc validation: all links valid, code references verified, no TODO/FIXME markers