### PR TITLE
TRE-37: List API endpoints — CRUD + reorder for lists

### DIFF
--- a/.orca/pr-url
+++ b/.orca/pr-url
@@ -1,0 +1,1 @@
+https://github.com/gutnikov/trello-clone/pull/6

--- a/.orca/state.json
+++ b/.orca/state.json
@@ -26,6 +26,15 @@
     "new_tests_passed": 6,
     "existing_tests_unaffected": true
   },
-  "attempt_count": 1,
+  "validation": {
+    "pr_url": "https://github.com/gutnikov/trello-clone/pull/6",
+    "ci_run": "https://github.com/gutnikov/trello-clone/actions/runs/23286294838",
+    "result": "FAIL",
+    "failure_reason": "mypy type errors in backend/src/app/routers/lists.py (5 errors: bare dict types, Any returns)",
+    "passing_checks": ["pre-commit", "pytest", "vitest", "deploy-staging", "e2e"],
+    "failing_checks": ["mypy"],
+    "fix_applied": "Added typing.Any import, parameterized dict return types to dict[str, Any], added explicit type annotations on model_dump() returns"
+  },
+  "attempt_count": 2,
   "status": "done"
 }

--- a/.orca/state.json
+++ b/.orca/state.json
@@ -1,6 +1,6 @@
 {
   "issue": "TRE-37",
-  "agent": "implementation",
+  "agent": "docs",
   "step": "completed",
   "scope_score": 6,
   "decision": "ATOMIC",
@@ -28,12 +28,28 @@
   },
   "validation": {
     "pr_url": "https://github.com/gutnikov/trello-clone/pull/6",
-    "ci_run": "https://github.com/gutnikov/trello-clone/actions/runs/23286294838",
-    "result": "FAIL",
-    "failure_reason": "mypy type errors in backend/src/app/routers/lists.py (5 errors: bare dict types, Any returns)",
-    "passing_checks": ["pre-commit", "pytest", "vitest", "deploy-staging", "e2e"],
-    "failing_checks": ["mypy"],
-    "fix_applied": "Added typing.Any import, parameterized dict return types to dict[str, Any], added explicit type annotations on model_dump() returns"
+    "ci_runs": [
+      "https://github.com/gutnikov/trello-clone/actions/runs/23286294838",
+      "https://github.com/gutnikov/trello-clone/actions/runs/23286549056"
+    ],
+    "result": "PASS",
+    "all_checks_pass": true,
+    "checks": {
+      "lint_format": "PASS",
+      "test": "PASS",
+      "deploy_staging": "PASS",
+      "e2e": "PASS"
+    }
+  },
+  "docs": {
+    "updated_files": [
+      "docs/agents/implementation.md",
+      "docs/agents/design-feedback-loop.md",
+      "README.md"
+    ],
+    "checklist_items_addressed": 3,
+    "checklist_items_total": 3,
+    "validation": "PASS"
   },
   "attempt_count": 2,
   "status": "done"

--- a/.orca/state.json
+++ b/.orca/state.json
@@ -49,8 +49,10 @@
     ],
     "checklist_items_addressed": 3,
     "checklist_items_total": 3,
-    "validation": "PASS"
+    "validation": "PASS",
+    "pr_description_updated": true
   },
+  "pr_url": "https://github.com/gutnikov/trello-clone/pull/6",
   "attempt_count": 2,
   "status": "done"
 }

--- a/.orca/state.json
+++ b/.orca/state.json
@@ -1,42 +1,31 @@
 {
-  "issue": "TRE-35",
+  "issue": "TRE-37",
   "agent": "implementation",
   "step": "completed",
-  "scope_score": 4,
+  "scope_score": 6,
   "decision": "ATOMIC",
   "affected_files": [
-    "backend/src/app/routers/__init__.py",
+    "backend/src/app/routers/lists.py",
     "backend/src/app/main.py",
-    "backend/tests/conftest.py",
-    "backend/tests/test_conftest_fixtures.py"
+    "backend/tests/test_api_lists.py"
   ],
   "subsystems": [
-    "fastapi-app-layer",
+    "fastapi-routing-layer",
     "test-infrastructure"
   ],
-  "retry_count": 0,
-  "attempt_count": 2,
-  "pr_url": "https://github.com/gutnikov/trello-clone/pull/5",
-  "ci_runs": [
-    "https://github.com/gutnikov/trello-clone/actions/runs/23285069007",
-    "https://github.com/gutnikov/trello-clone/actions/runs/23285069003"
-  ],
-  "tests_passing": [
-    "test_conftest_fixtures.py::TestDbFixture::test_db_fixture_provides_connected_database",
-    "test_conftest_fixtures.py::TestDbFixture::test_db_fixture_has_seeded_board",
-    "test_conftest_fixtures.py::TestDbFixture::test_db_fixture_isolation",
-    "test_conftest_fixtures.py::TestClientFixture::test_client_fixture_provides_async_client",
-    "test_conftest_fixtures.py::TestClientFixture::test_client_fixture_uses_test_db",
-    "test_main.py::TestCORSMiddleware::test_cors_allows_any_origin_by_default",
-    "test_main.py::TestCORSMiddleware::test_cors_preflight_returns_200",
-    "test_main.py::TestCORSMiddleware::test_cors_configured_origins_respected",
-    "test_main.py::TestLifespanLifecycle::test_app_state_has_db_after_startup",
-    "test_main.py::TestLifespanLifecycle::test_lifespan_seeds_default_board",
-    "test_main.py::TestLifespanLifecycle::test_health_endpoint_still_works"
-  ],
-  "validation_fixes": [
-    "Fixed ruff I001 import sorting violation in tests/test_main.py (removed extra blank line)",
-    "Fixed Docker startup failure by adding parent directory creation (Path.mkdir) before DB connect in lifespan"
-  ],
+  "artifacts": {
+    "plan": "docs/plans/TRE-37-plan.md",
+    "feedback_loop": "docs/feedback-loops/TRE-37-feedback.md",
+    "doc_impact": "docs/plans/TRE-37-doc-impact.md"
+  },
+  "test_results": {
+    "total": 53,
+    "failed": 0,
+    "passed": 53,
+    "errors": 0,
+    "new_tests_passed": 6,
+    "existing_tests_unaffected": true
+  },
+  "attempt_count": 1,
   "status": "done"
 }

--- a/.orca/state.json
+++ b/.orca/state.json
@@ -26,31 +26,30 @@
     "new_tests_passed": 6,
     "existing_tests_unaffected": true
   },
-  "validation": {
-    "pr_url": "https://github.com/gutnikov/trello-clone/pull/6",
-    "ci_runs": [
-      "https://github.com/gutnikov/trello-clone/actions/runs/23286294838",
-      "https://github.com/gutnikov/trello-clone/actions/runs/23286549056"
-    ],
+  "ci_results": {
     "result": "PASS",
-    "all_checks_pass": true,
-    "checks": {
+    "pr_url": "https://github.com/gutnikov/trello-clone/pull/6",
+    "ci_run": "https://github.com/gutnikov/trello-clone/actions/runs/23286745292",
+    "deploy_run": "https://github.com/gutnikov/trello-clone/actions/runs/23286745287",
+    "jobs": {
       "lint_format": "PASS",
       "test": "PASS",
-      "deploy_staging": "PASS",
+      "deploy_preview": "PASS",
       "e2e": "PASS"
     }
   },
-  "docs": {
+  "docs_validation": {
+    "result": "PASS",
+    "checklist_items_addressed": 3,
+    "checklist_items_total": 3,
+    "internal_links_valid": true,
+    "code_references_valid": true,
+    "no_todo_fixme": true,
     "updated_files": [
       "docs/agents/implementation.md",
       "docs/agents/design-feedback-loop.md",
       "README.md"
-    ],
-    "checklist_items_addressed": 3,
-    "checklist_items_total": 3,
-    "validation": "PASS",
-    "pr_description_updated": true
+    ]
   },
   "pr_url": "https://github.com/gutnikov/trello-clone/pull/6",
   "attempt_count": 2,

--- a/.orca/validation-report.md
+++ b/.orca/validation-report.md
@@ -1,54 +1,31 @@
 # Validation Report — TRE-37
 
-## CI Result: FAIL
+## CI Result: PASS
 
 **PR:** https://github.com/gutnikov/trello-clone/pull/6
 **Branch:** TRE-37
+**Attempt:** 2 (mypy fix applied in commit 792a109)
 **CI Workflow Runs:**
-- CI: https://github.com/gutnikov/trello-clone/actions/runs/23286294838
-- Deploy Staging: https://github.com/gutnikov/trello-clone/actions/runs/23286294828
+- CI: https://github.com/gutnikov/trello-clone/actions/runs/23286549056
+- Deploy Staging: https://github.com/gutnikov/trello-clone/actions/runs/23286549030
 
 ## Job Results
 
-| Job | Status | Duration |
-|-----|--------|----------|
-| Lint & Format | FAIL | 10s |
-| Test | PASS | 10s |
-| Deploy PR Preview | PASS | 22s |
-| E2E Tests | PASS | ~20s |
+| Job | Status |
+|-----|--------|
+| Lint & Format | PASS |
+| Test | PASS |
+| Deploy PR Preview | PASS |
+| E2E Tests | PASS |
 
-## Failure Details
+## Details
 
-### 1. Lint & Format — FAIL (blocking)
-
-**Step:** Type check (backend) — mypy
-**Error:** 5 mypy errors in `backend/src/app/routers/lists.py`:
-
-```
-src/app/routers/lists.py:40: error: Missing type parameters for generic type "dict"  [type-arg]
-src/app/routers/lists.py:48: error: Returning Any from function declared to return "dict[Any, Any]"  [no-any-return]
-src/app/routers/lists.py:52: error: Missing type parameters for generic type "dict"  [type-arg]
-src/app/routers/lists.py:68: error: Missing type parameters for generic type "dict"  [type-arg]
-src/app/routers/lists.py:75: error: Returning Any from function declared to return "dict[Any, Any]"  [no-any-return]
-Found 5 errors in 1 file (checked 7 source files)
-```
-
-**Root cause:** The `lists.py` router uses bare `dict` return type annotations instead of parameterized `dict[str, Any]` (lines 40, 52, 68), and two functions return `Any` values without explicit casting (lines 48, 75).
-
-**Fix required:**
-1. Replace bare `dict` return annotations with `dict[str, Any]` on lines 40, 52, and 68
-2. Add explicit `dict(...)` conversion or type-narrowing cast for return values on lines 48 and 75
-3. Run `cd backend && uv run python -m mypy src/` locally to verify all errors are resolved
-
-### Other Checks — All PASS
-
-- **Pre-commit (ruff lint/format + biome):** PASS
+- **Lint & Format:** All checks pass — ruff lint/format, biome lint/format, mypy, tsc (previous mypy errors fixed in commit 792a109)
 - **Backend tests (pytest):** PASS — all 53 tests pass including 6 new list endpoint tests
 - **Frontend tests (vitest):** PASS
-- **Deploy PR Preview:** PASS — staging stack healthy
+- **Deploy PR Preview:** PASS — staging stack deployed and healthy
 - **E2E Tests:** PASS
 
 ## Summary
 
-One fix needed before CI will pass:
-1. **Fix mypy type errors** in `backend/src/app/routers/lists.py` — add type parameters to bare `dict` annotations and handle `Any` return types
+All CI checks pass. The mypy type errors from attempt 1 were fixed by parameterizing bare `dict` return types to `dict[str, Any]` and adding explicit type annotations on `model_dump()` returns. PR is ready for review.

--- a/.orca/validation-report.md
+++ b/.orca/validation-report.md
@@ -1,57 +1,54 @@
-# Validation Report — TRE-35
+# Validation Report — TRE-37
 
 ## CI Result: FAIL
 
-**PR:** https://github.com/gutnikov/trello-clone/pull/5
-**Branch:** TRE-35
+**PR:** https://github.com/gutnikov/trello-clone/pull/6
+**Branch:** TRE-37
 **CI Workflow Runs:**
-- CI: https://github.com/gutnikov/trello-clone/actions/runs/23285069007
-- Deploy Staging: https://github.com/gutnikov/trello-clone/actions/runs/23285069003
+- CI: https://github.com/gutnikov/trello-clone/actions/runs/23286294838
+- Deploy Staging: https://github.com/gutnikov/trello-clone/actions/runs/23286294828
 
 ## Job Results
 
 | Job | Status | Duration |
 |-----|--------|----------|
 | Lint & Format | FAIL | 10s |
-| Test | PASS | 13s |
-| Deploy PR Preview | FAIL | 14s |
-| E2E Tests | SKIPPED | (depends on deploy) |
+| Test | PASS | 10s |
+| Deploy PR Preview | PASS | 22s |
+| E2E Tests | PASS | ~20s |
 
 ## Failure Details
 
 ### 1. Lint & Format — FAIL (blocking)
 
-**Step:** Run pre-commit
-**Error:** `ruff` hook found 1 auto-fixable lint error and modified files:
+**Step:** Type check (backend) — mypy
+**Error:** 5 mypy errors in `backend/src/app/routers/lists.py`:
 
 ```
-ruff (legacy alias)......................................................Failed
-- hook id: ruff
-- files were modified by this hook
-
-Found 1 error (1 fixed, 0 remaining).
+src/app/routers/lists.py:40: error: Missing type parameters for generic type "dict"  [type-arg]
+src/app/routers/lists.py:48: error: Returning Any from function declared to return "dict[Any, Any]"  [no-any-return]
+src/app/routers/lists.py:52: error: Missing type parameters for generic type "dict"  [type-arg]
+src/app/routers/lists.py:68: error: Missing type parameters for generic type "dict"  [type-arg]
+src/app/routers/lists.py:75: error: Returning Any from function declared to return "dict[Any, Any]"  [no-any-return]
+Found 5 errors in 1 file (checked 7 source files)
 ```
 
-**Root cause:** There is a ruff lint violation in the backend code that ruff can auto-fix. When pre-commit runs ruff with `--fix`, it modifies files, which causes the hook to fail (signaling the file was dirty).
+**Root cause:** The `lists.py` router uses bare `dict` return type annotations instead of parameterized `dict[str, Any]` (lines 40, 52, 68), and two functions return `Any` values without explicit casting (lines 48, 75).
 
-**Fix required:** Run `cd backend && uv run ruff check src/ tests/ --fix` locally, then commit the fixed files. Alternatively, run `cd backend && uv run pre-commit run --all-files` to identify and fix the exact file/issue.
+**Fix required:**
+1. Replace bare `dict` return annotations with `dict[str, Any]` on lines 40, 52, and 68
+2. Add explicit `dict(...)` conversion or type-narrowing cast for return values on lines 48 and 75
+3. Run `cd backend && uv run python -m mypy src/` locally to verify all errors are resolved
 
-### 2. Deploy PR Preview — FAIL (non-blocking for CI, but informational)
+### Other Checks — All PASS
 
-**Step:** Deploy preview stack
-**Error:** Backend container exited with code 3:
-
-```
-Container preview-pr-5-backend-1 Error dependency backend failed to start
-dependency failed to start: container preview-pr-5-backend-1 exited (3)
-```
-
-**Root cause:** The backend Docker container fails to start. This could be related to the lifespan changes (DB initialization at startup) or a missing dependency in the production Docker image (e.g., `aiosqlite` or `httpx` not in non-dev dependencies). The Dockerfile uses `uv sync --no-dev --no-install-project`, so only production dependencies are installed.
-
-**Fix required:** Check that all runtime dependencies (especially `aiosqlite`) are listed as non-dev dependencies in `backend/pyproject.toml`. Also verify the backend starts correctly with the new lifespan manager when no DB file path is configured.
+- **Pre-commit (ruff lint/format + biome):** PASS
+- **Backend tests (pytest):** PASS — all 53 tests pass including 6 new list endpoint tests
+- **Frontend tests (vitest):** PASS
+- **Deploy PR Preview:** PASS — staging stack healthy
+- **E2E Tests:** PASS
 
 ## Summary
 
-Two fixes needed before CI will pass:
-1. **Fix ruff lint violation** — run ruff check/fix and commit
-2. **Fix Docker startup** — ensure production dependencies are complete and lifespan works in containerized environment
+One fix needed before CI will pass:
+1. **Fix mypy type errors** in `backend/src/app/routers/lists.py` — add type parameters to bare `dict` annotations and handle `Any` return types

--- a/README.md
+++ b/README.md
@@ -20,6 +20,38 @@ A Trello-style kanban board application.
 
 Set `CORS_ORIGINS` to your frontend domain in production (e.g., `https://app.example.com`).
 
+## API Endpoints
+
+### Health
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/health` | Health check — returns `{"status": "ok", "version": "0.1.0"}` |
+
+### Lists
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/api/lists` | Create a new list |
+| `PUT` | `/api/lists/reorder` | Reorder lists on a board |
+| `PUT` | `/api/lists/{id}` | Update a list's title |
+| `DELETE` | `/api/lists/{id}` | Delete a list and its cards |
+
+**POST /api/lists** — Create a new list with auto-assigned position.
+- Request: `{ "title": "string", "board_id": "string" }`
+- Response: `201` with the created list object (`id`, `title`, `board_id`, `position`)
+
+**PUT /api/lists/{id}** — Update a list's title.
+- Request: `{ "title": "string" }`
+- Response: `200` with the updated list object, or `404` if not found
+
+**DELETE /api/lists/{id}** — Delete a list and all its cards (CASCADE).
+- Response: `204` No Content, or `404` if not found
+
+**PUT /api/lists/reorder** — Reorder lists on a board.
+- Request: `{ "list_ids": ["string"] }` (ordered array of list IDs)
+- Response: `200` with the reordered list of lists
+
 ## Getting Started
 
 ```bash

--- a/backend/src/app/main.py
+++ b/backend/src/app/main.py
@@ -10,6 +10,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from app.database import Database
 from app.logging import get_logger, setup_logging
+from app.routers.lists import router as lists_router
 
 setup_logging()
 log = get_logger()
@@ -49,6 +50,8 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+app.include_router(lists_router, prefix="/api")
 
 
 @app.get("/health")

--- a/backend/src/app/routers/lists.py
+++ b/backend/src/app/routers/lists.py
@@ -1,0 +1,86 @@
+"""List API endpoints: CRUD + reorder for lists on a board."""
+
+from fastapi import APIRouter, HTTPException, Request, Response
+from pydantic import BaseModel
+
+from app.logging import get_logger
+from app.models import List
+
+log = get_logger(module="routers.lists")
+
+router = APIRouter(tags=["lists"])
+
+
+# ── Request models ──────────────────────────────────────────────────────
+
+
+class CreateListRequest(BaseModel):
+    """Request body for creating a new list."""
+
+    title: str
+    board_id: str
+
+
+class UpdateListRequest(BaseModel):
+    """Request body for updating a list's title."""
+
+    title: str
+
+
+class ReorderListsRequest(BaseModel):
+    """Request body for reordering lists on a board."""
+
+    list_ids: list[str]
+
+
+# ── Endpoints ───────────────────────────────────────────────────────────
+
+
+@router.post("/lists", status_code=201)
+async def create_list(body: CreateListRequest, request: Request) -> dict:
+    """Create a new list with auto-assigned position."""
+    db = request.app.state.db
+    existing_lists = await db.get_lists_by_board(body.board_id)
+    position = len(existing_lists)
+    lst = List(title=body.title, board_id=body.board_id, position=position)
+    created = await db.create_list(lst)
+    log.info("list_created", list_id=created.id, board_id=body.board_id, position=position)
+    return created.model_dump()
+
+
+@router.put("/lists/reorder")
+async def reorder_lists(body: ReorderListsRequest, request: Request) -> list[dict]:
+    """Reorder lists on a board by updating positions to match the submitted order."""
+    db = request.app.state.db
+    if not body.list_ids:
+        return []
+    for index, list_id in enumerate(body.list_ids):
+        await db.update_list(list_id=list_id, position=index)
+    first_list = await db.get_list(body.list_ids[0])
+    if first_list is None:
+        return []
+    reordered = await db.get_lists_by_board(first_list.board_id)
+    log.info("lists_reordered", list_ids=body.list_ids, board_id=first_list.board_id)
+    return [lst.model_dump() for lst in reordered]
+
+
+@router.put("/lists/{list_id}")
+async def update_list(list_id: str, body: UpdateListRequest, request: Request) -> dict:
+    """Update a list's title."""
+    db = request.app.state.db
+    updated = await db.update_list(list_id=list_id, title=body.title)
+    if updated is None:
+        raise HTTPException(status_code=404, detail="List not found")
+    log.info("list_updated", list_id=list_id)
+    return updated.model_dump()
+
+
+@router.delete("/lists/{list_id}", status_code=204)
+async def delete_list(list_id: str, request: Request) -> Response:
+    """Delete a list and all its cards (CASCADE)."""
+    db = request.app.state.db
+    deleted = await db.delete_list(list_id=list_id)
+    if not deleted:
+        raise HTTPException(status_code=404, detail="List not found")
+    log.info("list_deleted", list_id=list_id)
+    return Response(status_code=204)

--- a/backend/src/app/routers/lists.py
+++ b/backend/src/app/routers/lists.py
@@ -1,5 +1,7 @@
 """List API endpoints: CRUD + reorder for lists on a board."""
 
+from typing import Any
+
 from fastapi import APIRouter, HTTPException, Request, Response
 from pydantic import BaseModel
 
@@ -37,7 +39,7 @@ class ReorderListsRequest(BaseModel):
 
 
 @router.post("/lists", status_code=201)
-async def create_list(body: CreateListRequest, request: Request) -> dict:
+async def create_list(body: CreateListRequest, request: Request) -> dict[str, Any]:
     """Create a new list with auto-assigned position."""
     db = request.app.state.db
     existing_lists = await db.get_lists_by_board(body.board_id)
@@ -45,11 +47,12 @@ async def create_list(body: CreateListRequest, request: Request) -> dict:
     lst = List(title=body.title, board_id=body.board_id, position=position)
     created = await db.create_list(lst)
     log.info("list_created", list_id=created.id, board_id=body.board_id, position=position)
-    return created.model_dump()
+    result: dict[str, Any] = created.model_dump()
+    return result
 
 
 @router.put("/lists/reorder")
-async def reorder_lists(body: ReorderListsRequest, request: Request) -> list[dict]:
+async def reorder_lists(body: ReorderListsRequest, request: Request) -> list[dict[str, Any]]:
     """Reorder lists on a board by updating positions to match the submitted order."""
     db = request.app.state.db
     if not body.list_ids:
@@ -65,14 +68,15 @@ async def reorder_lists(body: ReorderListsRequest, request: Request) -> list[dic
 
 
 @router.put("/lists/{list_id}")
-async def update_list(list_id: str, body: UpdateListRequest, request: Request) -> dict:
+async def update_list(list_id: str, body: UpdateListRequest, request: Request) -> dict[str, Any]:
     """Update a list's title."""
     db = request.app.state.db
     updated = await db.update_list(list_id=list_id, title=body.title)
     if updated is None:
         raise HTTPException(status_code=404, detail="List not found")
     log.info("list_updated", list_id=list_id)
-    return updated.model_dump()
+    result: dict[str, Any] = updated.model_dump()
+    return result
 
 
 @router.delete("/lists/{list_id}", status_code=204)

--- a/backend/tests/test_api_lists.py
+++ b/backend/tests/test_api_lists.py
@@ -13,7 +13,6 @@ Uses shared ``db`` and ``client`` fixtures from conftest.py.
 """
 
 import httpx
-import pytest
 
 from app.database import Database
 from app.models import Card, List

--- a/backend/tests/test_api_lists.py
+++ b/backend/tests/test_api_lists.py
@@ -1,0 +1,200 @@
+"""Tests for the List API endpoints.
+
+Verifies CRUD + reorder operations on lists:
+- POST /api/lists creates a list with correct auto-assigned position
+- PUT /api/lists/{id} updates a list's title
+- PUT /api/lists/{id} returns 404 for non-existent list
+- DELETE /api/lists/{id} removes list and its cards (CASCADE)
+- DELETE /api/lists/{id} returns 404 for non-existent list
+- PUT /api/lists/reorder updates list positions correctly
+
+These tests correspond to the feedback loop plan in docs/feedback-loops/TRE-37-feedback.md.
+Uses shared ``db`` and ``client`` fixtures from conftest.py.
+"""
+
+import httpx
+import pytest
+
+from app.database import Database
+from app.models import Card, List
+
+
+class TestCreateList:
+    """Tests for POST /api/lists — create a new list."""
+
+    async def test_create_list_with_correct_position(
+        self, client: httpx.AsyncClient, db: Database
+    ) -> None:
+        """POST /api/lists creates a list with auto-assigned position.
+
+        First list gets position 0, second list gets position 1.
+        Response includes id, title, board_id, and position fields.
+        """
+        boards = await db.list_boards()
+        board_id = boards[0].id
+
+        # Create first list — should get position 0
+        response = await client.post(
+            "/api/lists",
+            json={"title": "Todo", "board_id": board_id},
+        )
+        assert response.status_code == 201, (
+            f"POST /api/lists should return 201 Created, got {response.status_code}"
+        )
+        data = response.json()
+        assert data["title"] == "Todo", f"Expected title 'Todo', got {data.get('title')!r}"
+        assert data["board_id"] == board_id, (
+            f"Expected board_id '{board_id}', got {data.get('board_id')!r}"
+        )
+        assert data["position"] == 0, (
+            f"First list should have position 0, got {data.get('position')!r}"
+        )
+        assert "id" in data, "Response should include 'id' field"
+
+        # Create second list — should get position 1
+        response2 = await client.post(
+            "/api/lists",
+            json={"title": "Doing", "board_id": board_id},
+        )
+        assert response2.status_code == 201, (
+            f"Second POST /api/lists should return 201 Created, got {response2.status_code}"
+        )
+        data2 = response2.json()
+        assert data2["position"] == 1, (
+            f"Second list should have position 1, got {data2.get('position')!r}"
+        )
+
+
+class TestUpdateList:
+    """Tests for PUT /api/lists/{id} — update list title."""
+
+    async def test_update_list_title(self, client: httpx.AsyncClient, db: Database) -> None:
+        """PUT /api/lists/{id} updates the list title and returns the updated list.
+
+        The list ID and board_id remain unchanged after the update.
+        """
+        boards = await db.list_boards()
+        board_id = boards[0].id
+        lst = await db.create_list(List(title="Original", board_id=board_id, position=0))
+
+        response = await client.put(
+            f"/api/lists/{lst.id}",
+            json={"title": "Updated"},
+        )
+        assert response.status_code == 200, (
+            f"PUT /api/lists/{{id}} should return 200, got {response.status_code}"
+        )
+        data = response.json()
+        assert data["title"] == "Updated", (
+            f"Expected updated title 'Updated', got {data.get('title')!r}"
+        )
+        assert data["id"] == lst.id, (
+            f"List ID should remain unchanged: expected {lst.id!r}, got {data.get('id')!r}"
+        )
+        assert data["board_id"] == board_id, (
+            f"board_id should remain unchanged: expected {board_id!r}, got {data.get('board_id')!r}"
+        )
+
+    async def test_update_list_returns_404_for_nonexistent(self, client: httpx.AsyncClient) -> None:
+        """PUT /api/lists/{id} returns 404 with a JSON detail message for a non-existent list."""
+        response = await client.put(
+            "/api/lists/nonexistent-uuid",
+            json={"title": "X"},
+        )
+        assert response.status_code == 404, (
+            f"PUT /api/lists/nonexistent-uuid should return 404, got {response.status_code}"
+        )
+        data = response.json()
+        assert "detail" in data, (
+            "404 response should include a 'detail' field with an error message"
+        )
+        assert data["detail"] == "List not found", (
+            f"Expected detail 'List not found', got {data['detail']!r}"
+        )
+
+
+class TestDeleteList:
+    """Tests for DELETE /api/lists/{id} — delete list and CASCADE to cards."""
+
+    async def test_delete_list_removes_list_and_cards(
+        self, client: httpx.AsyncClient, db: Database
+    ) -> None:
+        """DELETE /api/lists/{id} returns 204, removes the list and its cards via CASCADE.
+
+        After deletion, both db.get_list(list_id) and db.get_card(card_id)
+        return None.
+        """
+        boards = await db.list_boards()
+        board_id = boards[0].id
+        lst = await db.create_list(List(title="To Delete", board_id=board_id, position=0))
+        card = await db.create_card(Card(title="Card on deleted list", list_id=lst.id, position=0))
+
+        response = await client.delete(f"/api/lists/{lst.id}")
+        assert response.status_code == 204, (
+            f"DELETE /api/lists/{{id}} should return 204 No Content, got {response.status_code}"
+        )
+
+        # Verify list is gone
+        deleted_list = await db.get_list(lst.id)
+        assert deleted_list is None, (
+            f"List should be deleted from database, but get_list returned {deleted_list!r}"
+        )
+
+        # Verify card is gone (CASCADE delete)
+        deleted_card = await db.get_card(card.id)
+        assert deleted_card is None, (
+            f"Card should be CASCADE-deleted, but get_card returned {deleted_card!r}"
+        )
+
+    async def test_delete_list_returns_404_for_nonexistent(self, client: httpx.AsyncClient) -> None:
+        """DELETE /api/lists/{id} returns 404 for a non-existent list."""
+        response = await client.delete("/api/lists/nonexistent-uuid")
+        assert response.status_code == 404, (
+            f"DELETE /api/lists/nonexistent-uuid should return 404, got {response.status_code}"
+        )
+        data = response.json()
+        assert data["detail"] == "List not found", (
+            f"Expected detail 'List not found', got {data.get('detail')!r}"
+        )
+
+
+class TestReorderLists:
+    """Tests for PUT /api/lists/reorder — reorder lists on a board."""
+
+    async def test_reorder_lists_updates_positions(
+        self, client: httpx.AsyncClient, db: Database
+    ) -> None:
+        """PUT /api/lists/reorder updates positions to match submitted list_ids order.
+
+        Creates 3 lists (positions 0, 1, 2), reorders them, and verifies
+        the new positions are persisted correctly.
+        """
+        boards = await db.list_boards()
+        board_id = boards[0].id
+
+        lst_0 = await db.create_list(List(title="List A", board_id=board_id, position=0))
+        lst_1 = await db.create_list(List(title="List B", board_id=board_id, position=1))
+        lst_2 = await db.create_list(List(title="List C", board_id=board_id, position=2))
+
+        # Reorder: C, A, B
+        response = await client.put(
+            "/api/lists/reorder",
+            json={"list_ids": [lst_2.id, lst_0.id, lst_1.id]},
+        )
+        assert response.status_code == 200, (
+            f"PUT /api/lists/reorder should return 200, got {response.status_code}"
+        )
+
+        # Verify positions are persisted correctly via database
+        reordered = await db.get_lists_by_board(board_id)
+        reordered_ids = [lst.id for lst in reordered]
+        expected_order = [lst_2.id, lst_0.id, lst_1.id]
+        assert reordered_ids == expected_order, (
+            f"Lists should be reordered to {expected_order}, but got {reordered_ids}"
+        )
+
+        # Verify positions are sequential 0, 1, 2
+        positions = [lst.position for lst in reordered]
+        assert positions == [0, 1, 2], (
+            f"Positions should be [0, 1, 2] after reorder, got {positions}"
+        )

--- a/docs/agents/design-feedback-loop.md
+++ b/docs/agents/design-feedback-loop.md
@@ -26,5 +26,16 @@
 - **Available fixtures:** `db` (in-memory Database with schema + seeded default board), `client` (httpx AsyncClient wired to the test app)
 - When writing test scaffolds for API endpoint tests, use the `db` and `client` fixtures from conftest rather than creating new fixture setup. Tests can simply declare `db: Database` or `client: httpx.AsyncClient` as parameters.
 
+### Canonical API Endpoint Test Pattern
+- **Reference:** `backend/tests/test_api_lists.py` — the canonical example for API endpoint test scaffolds.
+- **Structure:** Organize tests into classes by operation (e.g., `TestCreateList`, `TestUpdateList`, `TestDeleteList`, `TestReorderLists`). Each class groups related test cases for a single endpoint.
+- **Patterns to follow:**
+  - Use `db` fixture to set up preconditions (create boards, lists, cards) via `Database` methods before calling the API.
+  - Use `client` fixture (`httpx.AsyncClient`) to make HTTP requests against the test app.
+  - Test auto-assigned position management (verify sequential positions on creation).
+  - Test 404 handling for non-existent resources with both status code and `detail` message assertions.
+  - Test CASCADE delete behavior by verifying child entities (e.g., cards) are removed when a parent (e.g., list) is deleted.
+  - Include descriptive assertion messages explaining expected vs. actual values.
+
 ### Staging
 - **Available:** yes (per-PR Docker Compose preview deploys on `2.56.122.47`)

--- a/docs/agents/implementation.md
+++ b/docs/agents/implementation.md
@@ -68,7 +68,7 @@ The `lists.py` router (`backend/src/app/routers/lists.py`) establishes the canon
 4. **Structured logging** — Use `from app.logging import get_logger` with a `module` parameter (e.g., `get_logger(module="routers.lists")`). Log one event per endpoint action (e.g., `list_created`, `list_updated`, `list_deleted`).
 5. **Return types** — Return `dict[str, Any]` (via `model.model_dump()`) for single-entity responses, `list[dict[str, Any]]` for collections. Use `Response(status_code=204)` for delete endpoints.
 6. **Error handling** — Raise `HTTPException(status_code=404, detail="<Entity> not found")` when a requested resource does not exist.
-7. **Router registration** — Import the router in `backend/src/app/main.py` and register it with `app.include_router(router, prefix="/api")`. See `main.py:54` for the lists router registration.
+7. **Router registration** — Import the router in `backend/src/app/main.py` and register it with `app.include_router(router, prefix="/api")`. See `main.py:57` for the lists router registration.
 
 ### API Router Pattern
 The canonical pattern for implementing API routers is established in `backend/src/app/routers/boards.py`. Follow this pattern for new routers:
@@ -78,7 +78,7 @@ The canonical pattern for implementing API routers is established in `backend/sr
 - **Router declaration:** Use `APIRouter(tags=["..."])` with no prefix on the router itself. The prefix (`/api`) is set at registration in `main.py` via `app.include_router(router, prefix="/api")`.
 - **Response models:** Set `response_model=` on each route decorator for automatic response validation and OpenAPI docs.
 - **Logging:** Include structlog logging in each handler for observability (e.g., `log.info("board_updated", board_id=board.id)`).
-- **Registration:** Import the router in `main.py` and register with `app.include_router(router, prefix="/api")`. See `backend/src/app/main.py:54` for the existing registration pattern.
+- **Registration:** Import the router in `main.py` and register with `app.include_router(router, prefix="/api")`. See `backend/src/app/main.py:55` for the existing registration pattern.
 
 ### Shared Test Fixtures
 - **Location:** `backend/tests/conftest.py`

--- a/docs/agents/implementation.md
+++ b/docs/agents/implementation.md
@@ -56,7 +56,19 @@
 ### App Configuration
 - **CORS:** Configured in `backend/src/app/main.py` via `CORSMiddleware`. Defaults to allow all origins (`*`) for dev. Set `CORS_ORIGINS` env var (comma-separated) for production.
 - **Lifespan:** The `lifespan` async context manager in `main.py` connects to the database, initializes the schema, seeds the default board on startup, and closes the DB on shutdown. The `Database` instance is available at `app.state.db`.
-- **Router package:** `backend/src/app/routers/__init__.py` is the router package. Add new endpoint modules (e.g., `boards.py`, `lists.py`, `cards.py`) here and include them in the app.
+- **Router package:** `backend/src/app/routers/__init__.py` is the router package. Add new endpoint modules (e.g., `boards.py`, `cards.py`) here and register them in `main.py`.
+
+### Router Implementation Pattern
+
+The `lists.py` router (`backend/src/app/routers/lists.py`) establishes the canonical pattern for API endpoint modules. Future routers (boards, cards) should follow this template:
+
+1. **Pydantic request models** — Define request body schemas (e.g., `CreateListRequest`, `UpdateListRequest`) as `BaseModel` subclasses directly in the router file. These validate input at the boundary.
+2. **Database access** — Access the database via `request.app.state.db` (the `Database` instance injected during app lifespan). Do not import or instantiate the database directly.
+3. **Route ordering** — Define static path routes (e.g., `PUT /lists/reorder`) **before** parameterized path routes (e.g., `PUT /lists/{list_id}`). FastAPI matches routes in definition order, so `/lists/reorder` must come before `/lists/{list_id}` to avoid `"reorder"` being captured as a `list_id` parameter.
+4. **Structured logging** — Use `from app.logging import get_logger` with a `module` parameter (e.g., `get_logger(module="routers.lists")`). Log one event per endpoint action (e.g., `list_created`, `list_updated`, `list_deleted`).
+5. **Return types** — Return `dict[str, Any]` (via `model.model_dump()`) for single-entity responses, `list[dict[str, Any]]` for collections. Use `Response(status_code=204)` for delete endpoints.
+6. **Error handling** — Raise `HTTPException(status_code=404, detail="<Entity> not found")` when a requested resource does not exist.
+7. **Router registration** — Import the router in `backend/src/app/main.py` and register it with `app.include_router(router, prefix="/api")`. See `main.py:54` for the lists router registration.
 
 ### Shared Test Fixtures
 - **Location:** `backend/tests/conftest.py`

--- a/docs/feedback-loops/TRE-37-feedback.md
+++ b/docs/feedback-loops/TRE-37-feedback.md
@@ -1,0 +1,135 @@
+# Feedback Loop Plan: TRE-37
+
+## Overview
+
+Verification strategy for the list API router: four CRUD + reorder endpoints (`POST /api/lists`, `PUT /api/lists/{id}`, `DELETE /api/lists/{id}`, `PUT /api/lists/reorder`). Tests exercise all endpoints through the httpx test client, verifying correct HTTP status codes, response payloads, position auto-assignment, CASCADE deletion, and reorder persistence. Observability is provided through structured logging on each endpoint.
+
+---
+
+## Feedback Completeness Score: 8/10
+
+| Method | Score | Notes |
+|--------|-------|-------|
+| Unit tests | 3 | 6 test cases covering all 4 endpoints plus error paths |
+| Integration tests | 2 | Tests exercise full HTTP→router→database→response stack |
+| E2E tests | 0 | N/A — backend-only API endpoints; no user-facing frontend component in this issue |
+| Observability | 2 | 4 structured log events covering all endpoint operations |
+| Runtime validation | 1 | Health check non-regression + test suite re-run |
+| **Total** | **8** | |
+
+---
+
+## 1. Unit Tests — List API Endpoints (`backend/tests/test_api_lists.py`)
+
+These tests use the shared `db` and `client` fixtures from `backend/tests/conftest.py`. The `db` fixture provides an in-memory SQLite database with schema initialized and default board seeded. The `client` fixture provides an httpx AsyncClient wired to the FastAPI test app.
+
+### Test Cases
+
+| Test Name | Expected Behavior |
+|---|---|
+| `test_create_list_with_correct_position` | `POST /api/lists` with `{"title": "Todo", "board_id": "<seeded_board_id>"}` returns 201 with the created list containing `position: 0`. A second POST returns `position: 1`. Response body includes `id`, `title`, `board_id`, and `position` fields. |
+| `test_update_list_title` | Create a list via `db.create_list(...)`, then `PUT /api/lists/{id}` with `{"title": "Updated"}` returns 200 with `title: "Updated"`. The list ID and board_id remain unchanged. |
+| `test_update_list_returns_404_for_nonexistent` | `PUT /api/lists/nonexistent-uuid` with `{"title": "X"}` returns 404 with a JSON detail message. |
+| `test_delete_list_removes_list_and_cards` | Create a list via `db.create_list(...)` and a card on it via `db.create_card(...)`. `DELETE /api/lists/{list_id}` returns 204 (no content body). Subsequently, `db.get_list(list_id)` returns `None` and `db.get_card(card_id)` returns `None` (CASCADE delete verified). |
+| `test_delete_list_returns_404_for_nonexistent` | `DELETE /api/lists/nonexistent-uuid` returns 404. |
+| `test_reorder_lists_updates_positions` | Create 3 lists with positions 0, 1, 2. `PUT /api/lists/reorder` with `{"list_ids": [id_2, id_0, id_1]}` returns 200. The response contains lists ordered by their new positions. Verify via `db.get_lists_by_board()` that positions are persisted as 0, 1, 2 matching the submitted order. |
+
+### Run Command
+
+```bash
+cd backend && uv run python -m pytest tests/test_api_lists.py -v
+```
+
+---
+
+## 2. Integration Tests — Router↔Database Stack
+
+The unit tests above are inherently integration tests because they exercise the full HTTP request/response cycle through FastAPI's ASGI transport into the actual database layer (in-memory SQLite). Each test verifies:
+
+- HTTP request parsing (Pydantic request model validation)
+- Router handler logic (position computation, error handling)
+- Database CRUD operations (via `Database` methods)
+- HTTP response serialization (JSON response with correct status code)
+
+### Additional Integration Verification
+
+| Scenario | What It Verifies |
+|---|---|
+| Route ordering (`/lists/reorder` before `/lists/{id}`) | The reorder endpoint is reachable and doesn't get captured by the `{id}` parameter route |
+| CASCADE delete | SQLite foreign key enforcement is active in the test database; deleting a list cascades to its cards |
+| Position auto-assignment | The create endpoint queries existing lists and computes the next position, testing the full database round-trip |
+
+These are implicitly covered by the unit test cases above rather than requiring separate test functions.
+
+### Run Command
+
+```bash
+cd backend && uv run python -m pytest tests/test_api_lists.py -v
+```
+
+---
+
+## 3. E2E Tests
+
+**N/A** — This issue adds backend API endpoints only. There is no frontend component, no user-facing UI, and no browser interaction. E2E testing will become relevant when the frontend consumes these endpoints (a separate issue). While staging is available per `docs/agents/design-feedback-loop.md`, there are no user flows to test against it for this backend-only change.
+
+---
+
+## 4. Observability
+
+The list router includes structured logging via `structlog` for runtime observability. Each endpoint logs a structured event on successful operation.
+
+### Logs
+
+| Event | Log Level | Fields | Purpose |
+|---|---|---|---|
+| `list_created` | `info` | `list_id`, `board_id`, `position` | Confirms a new list was created with its assigned position |
+| `list_updated` | `info` | `list_id` | Confirms a list title was updated |
+| `list_deleted` | `info` | `list_id` | Confirms a list was deleted (CASCADE includes cards) |
+| `lists_reordered` | `info` | `board_id`, `count` | Confirms lists were reordered on a board, with count of lists affected |
+
+These events complement the existing database-level logging (`database_connected`, `schema_initialized`) and the app-level logging (`app_startup_complete`). Together they provide a request-level audit trail for list operations.
+
+### Metrics
+
+N/A — The project does not have a metrics collection framework (no Prometheus, StatsD, or similar). Adding metrics infrastructure is out of scope for this issue.
+
+### Traces
+
+N/A — The project does not use distributed tracing. Single-process SQLite backend does not benefit from trace spans at this stage.
+
+---
+
+## 5. Runtime Validation
+
+### Non-Regression
+
+After implementing the list router, verify that existing tests continue to pass:
+
+```bash
+cd backend && uv run python -m pytest -v
+```
+
+This confirms that:
+- Router registration in `main.py` doesn't break the `/health` endpoint
+- The shared `conftest.py` fixtures still work for all existing test modules
+- No import errors introduced by the new router module
+
+### Static Analysis
+
+```bash
+cd backend && uv run ruff check src/app/routers/lists.py src/app/main.py tests/test_api_lists.py
+cd backend && uv run mypy src/app/routers/lists.py src/app/main.py --strict
+```
+
+Verifies:
+- Import ordering and linting compliance
+- Type annotations are complete and correct
+- No unused imports or variables
+- Async patterns follow project conventions
+
+---
+
+## Summary
+
+The feedback loop is dominated by unit/integration tests since this is a thin routing layer over an already-tested database layer. The six test cases cover all four endpoints, both success and error paths, position auto-assignment logic, CASCADE delete behavior, and reorder persistence. Observability via structured logging provides production-level audit trails without requiring additional infrastructure. The feedback_completeness_score of 8 exceeds the minimum threshold of 6.

--- a/docs/plans/TRE-37-doc-impact.md
+++ b/docs/plans/TRE-37-doc-impact.md
@@ -1,0 +1,42 @@
+# Doc Impact Analysis: TRE-37
+
+## Summary
+
+TRE-37 adds the first API router module (`lists.py`) with four CRUD + reorder endpoints and registers it in `main.py`. This is the first concrete router in the `routers/` package established by TRE-35. The primary doc impact is updating agent context docs to reflect the new router pattern so that subsequent endpoint issues (boards, cards) follow the same conventions.
+
+---
+
+## Checklist
+
+- [x] `docs/agents/implementation.md` — UPDATE: Document the router implementation pattern established by `lists.py` — Pydantic request models defined in the router file, `request.app.state.db` for database access, route ordering requirement for parameterized vs. static paths, structured logging per endpoint, and `app.include_router(router, prefix="/api")` registration pattern in `main.py`. Future endpoint agents (boards router, cards router) should follow this template.
+
+- [x] `docs/agents/design-feedback-loop.md` — UPDATE: Add `lists.py` router as a reference pattern for API endpoint test scaffolds. Future Design Feedback Loop Agents writing tests for board or card endpoints should reference `test_api_lists.py` as the canonical example of how to use the `db` and `client` fixtures to test CRUD endpoints with position management, 404 handling, and CASCADE delete verification.
+
+- [x] `README.md` — UPDATE: Add API endpoint documentation section listing the four list endpoints (`POST /api/lists`, `PUT /api/lists/{id}`, `DELETE /api/lists/{id}`, `PUT /api/lists/reorder`) with their request/response schemas. This is the first set of business endpoints beyond `/health`.
+
+---
+
+## No Impact
+
+The following categories were checked and require no update:
+
+- `docs/architecture/` — No new architectural decisions. The router pattern is standard FastAPI and does not warrant an ADR. The database layer, model structure, and test infrastructure were all established in prior issues.
+- `docs/conventions/golden-principles.md` — No new conventions introduced. The router follows existing principles (one responsibility per file, validate at boundaries, TDD).
+- `docs/guides/workflow-customization.md` — Orca workflow unchanged.
+- `docs/agents/scoping.md` — Scoping process and subsystem boundaries unchanged.
+- `docs/agents/planning.md` — Planning process unchanged.
+- `docs/agents/validation.md` — Validation process unchanged.
+- `docs/agents/docs-update.md` — Documentation update process unchanged.
+- `docs/runbooks/` — No operational procedures changed; list endpoints don't introduce new operational concerns beyond what the app already has.
+- `docs/specs/` — No specs directory exists; implementation matches issue specification exactly.
+- `deploy/` — No deployment configuration changes needed; the router is automatically included via `main.py` registration.
+
+---
+
+## Summary Table
+
+| Document | Impact Level | Action |
+|---|---|---|
+| `docs/agents/implementation.md` | Medium | **Update** — document router pattern for future endpoint agents |
+| `docs/agents/design-feedback-loop.md` | Low | **Update** — reference `test_api_lists.py` as canonical test pattern |
+| `README.md` | Low | **Update** — add list API endpoint documentation |

--- a/docs/plans/TRE-37-plan.md
+++ b/docs/plans/TRE-37-plan.md
@@ -1,0 +1,116 @@
+# Implementation Plan: TRE-37
+
+## Overview
+
+Implement a FastAPI list router with four endpoints (create, update title, delete, reorder) that delegate to the existing `Database` CRUD methods. The router module defines Pydantic request models, retrieves `request.app.state.db` to access the database, and returns appropriate HTTP status codes. Registration in `main.py` adds two lines. Tests use the shared `db` and `client` fixtures from `conftest.py` to exercise all six specified scenarios.
+
+## Steps
+
+### Step 1: Create the list router module
+
+- **Files:** `backend/src/app/routers/lists.py` (new)
+- **Changes:**
+  - Define Pydantic request models:
+    - `CreateListRequest` with fields `title: str` and `board_id: str`
+    - `UpdateListRequest` with field `title: str`
+    - `ReorderListsRequest` with field `list_ids: list[str]`
+  - Create `router = APIRouter(tags=["lists"])` (no prefix — the prefix is applied during registration in `main.py`)
+  - Import `get_logger` from `app.logging` and create a module-level logger
+  - Implement four endpoints:
+
+  **`POST /lists`** — Create a new list
+  1. Extract `db` from `request.app.state.db`
+  2. Compute the next available position by calling `db.get_lists_by_board(body.board_id)` and setting `position = len(existing_lists)`
+  3. Construct a `List` model instance with `title=body.title`, `board_id=body.board_id`, `position=position`
+  4. Call `db.create_list(lst)` and return the created list with `status_code=201`
+  5. Log `list_created` with list_id, board_id, position
+
+  **`PUT /lists/{id}`** — Update list title
+  1. Extract `db` from `request.app.state.db`
+  2. Call `db.update_list(list_id=id, title=body.title)`
+  3. If result is `None`, raise `HTTPException(status_code=404, detail="List not found")`
+  4. Return the updated list
+  5. Log `list_updated` with list_id
+
+  **`DELETE /lists/{id}`** — Delete list (CASCADE handles cards)
+  1. Extract `db` from `request.app.state.db`
+  2. Call `db.delete_list(list_id=id)`
+  3. If result is `False`, raise `HTTPException(status_code=404, detail="List not found")`
+  4. Return `Response(status_code=204)` (no content)
+  5. Log `list_deleted` with list_id
+
+  **`PUT /lists/reorder`** — Reorder lists on a board
+  1. Extract `db` from `request.app.state.db`
+  2. Iterate over `body.list_ids` with `enumerate()` to get `(index, list_id)` pairs
+  3. For each pair, call `db.update_list(list_id=list_id, position=index)`
+  4. After updating all positions, determine the board_id from the first list (call `db.get_list(body.list_ids[0])` to get the board_id) and return the reordered lists via `db.get_lists_by_board(board_id)`
+  5. Log `lists_reordered` with list_ids and board_id
+
+  **IMPORTANT routing order:** The `PUT /lists/reorder` route must be defined *before* `PUT /lists/{id}` in the file, otherwise FastAPI will match "reorder" as a path parameter `{id}`. This is critical for correct URL resolution.
+
+- **Depends on:** None (uses existing `Database` methods and `List` model)
+
+### Step 2: Register the list router in main.py
+
+- **Files:** `backend/src/app/main.py` (modify)
+- **Changes:**
+  - Add import: `from app.routers.lists import router as lists_router`
+  - Add registration: `app.include_router(lists_router, prefix="/api")` — place this after the CORS middleware setup and before the `/health` endpoint definition
+  - This follows the pattern described in `routers/__init__.py` docstring and matches the `prefix="/api"` convention specified in the issue
+- **Depends on:** Step 1 (the router module must exist)
+
+### Step 3: Create list API tests
+
+- **Files:** `backend/tests/test_api_lists.py` (new)
+- **Changes:**
+  - Import `pytest`, `httpx`, `Database` from `app.database`, `Card` from `app.models`
+  - Use the shared `client` and `db` fixtures from `conftest.py` (function-scoped, in-memory DB with seeded default board)
+  - Implement six test cases:
+
+  **`test_create_list_with_correct_position`**
+  - Use `db.list_boards()` to get the seeded board's ID
+  - POST `/api/lists` with `{"title": "Todo", "board_id": board_id}`
+  - Assert status 201, response contains `title: "Todo"`, `board_id: board_id`, `position: 0`
+  - POST another list and assert `position: 1`
+
+  **`test_update_list_title`**
+  - Create a list via `db.create_list(...)` directly
+  - PUT `/api/lists/{list_id}` with `{"title": "Updated Title"}`
+  - Assert status 200, response contains `title: "Updated Title"`
+
+  **`test_update_list_returns_404_for_nonexistent`**
+  - PUT `/api/lists/nonexistent-id` with `{"title": "X"}`
+  - Assert status 404
+
+  **`test_delete_list_removes_list_and_cards`**
+  - Create a list via `db.create_list(...)`
+  - Create a card on that list via `db.create_card(...)`
+  - DELETE `/api/lists/{list_id}`
+  - Assert status 204
+  - Verify list is gone: `db.get_list(list_id)` returns `None`
+  - Verify card is gone: `db.get_card(card_id)` returns `None` (CASCADE delete)
+
+  **`test_delete_list_returns_404_for_nonexistent`**
+  - DELETE `/api/lists/nonexistent-id`
+  - Assert status 404
+
+  **`test_reorder_lists_updates_positions`**
+  - Create two or three lists via `db.create_list(...)` with positions 0, 1, 2
+  - PUT `/api/lists/reorder` with `{"list_ids": [id_2, id_0, id_1]}` (reversed/shuffled order)
+  - Assert status 200
+  - Verify the response contains lists in the new order with positions 0, 1, 2 matching the submitted order
+  - Optionally verify via `db.get_lists_by_board()` that the positions are persisted correctly
+
+- **Depends on:** Steps 1-2 (router must be registered for the test client to hit the endpoints)
+
+## Risk Factors
+
+- **Route ordering for `/lists/reorder` vs `/lists/{id}`** — If the reorder endpoint is defined after the parameterized update endpoint, FastAPI will interpret "reorder" as a list ID and route to the update handler. Mitigation: define the `PUT /lists/reorder` route before `PUT /lists/{id}` in the router file. This is a well-known FastAPI pattern.
+
+- **Position auto-assignment race condition** — The create endpoint computes position by counting existing lists. If two concurrent requests create lists simultaneously, they could get the same position. Mitigation: SQLite serializes writes via WAL mode, and the app is single-process for now. This is acceptable for the current scale; a future issue can add database-level position management if needed.
+
+- **Reorder endpoint with invalid list IDs** — If `list_ids` contains IDs that don't exist, `db.update_list()` returns `None` but the endpoint silently continues. Mitigation: the current issue scope doesn't require validation of list IDs in the reorder body. The endpoint updates what it can and returns the result. This matches the pragmatic approach of the existing codebase. Validation can be added as a follow-up if needed.
+
+- **Reorder endpoint with empty `list_ids`** — If the array is empty, the endpoint would attempt `db.get_list(body.list_ids[0])` and raise an `IndexError`. Mitigation: the implementation should handle the empty case by returning an empty list or a 400 error. The plan recommends returning an empty list `[]` for simplicity.
+
+- **CASCADE delete verification in tests** — The test for delete-with-cards relies on SQLite's `PRAGMA foreign_keys=ON` being enabled in the test database. The `conftest.py` `db` fixture calls `db.connect()` which enables foreign keys. This is already handled by the existing infrastructure.

--- a/docs/plans/TRE-37-scope.md
+++ b/docs/plans/TRE-37-scope.md
@@ -1,0 +1,29 @@
+# Scope Report: TRE-37
+
+## Summary
+This issue implements the list API router with four CRUD + reorder endpoints for the Trello clone backend. The database layer (`Database` class) already provides all required CRUD methods (`create_list`, `get_list`, `update_list`, `delete_list`, `get_lists_by_board`), so the work is a thin routing layer that delegates to existing persistence methods plus a test module exercising the endpoints. The test infrastructure (conftest.py with `db` and `client` fixtures) is already in place.
+
+## Affected Files
+- `backend/src/app/routers/lists.py` — **NEW** — FastAPI router with 4 endpoints: POST /api/lists (create), PUT /api/lists/{id} (update title), DELETE /api/lists/{id} (delete), PUT /api/lists/reorder (reorder positions). Each endpoint accesses `request.app.state.db` for database operations.
+- `backend/src/app/main.py` — **MODIFY** — Add `from app.routers.lists import router as lists_router` and `app.include_router(lists_router, prefix="/api")` (~2 lines added)
+- `backend/tests/test_api_lists.py` — **NEW** — 6 test cases using the existing `client` and `db` fixtures from conftest.py: create list with correct position, update title, update 404, delete list and cards, delete 404, reorder positions
+
+## Subsystems Involved
+- **FastAPI routing layer** — New router module with endpoint definitions, request/response models, and HTTP status code handling
+- **Test infrastructure** — New test module leveraging existing shared fixtures (in-memory DB + httpx AsyncClient)
+
+## Scope Score: 6/10
+- Files: 1pt (3 files affected)
+- Subsystems: 2pt (2 subsystems: routing layer + test suite)
+- LOC estimate: 1pt (~100-130 lines total — router ~60-70 lines for 4 endpoints with Pydantic request models, main.py ~2 lines, tests ~60-80 lines for 6 test cases)
+- Migration: 0pt (no schema changes; all tables and CRUD methods already exist in database.py)
+- API surface: 2pt (4 new public HTTP endpoints exposed)
+- **Total: 6/10**
+
+## Decision: ATOMIC
+The scope score of 6 is at the atomic threshold. Key factors supporting an atomic decision:
+1. **Database layer is complete** — All five list CRUD methods (`create_list`, `get_list`, `update_list`, `delete_list`, `get_lists_by_board`) already exist in `database.py` with full implementation
+2. **Test infrastructure exists** — The `conftest.py` provides `db` (in-memory Database) and `client` (httpx AsyncClient) fixtures ready to use
+3. **Clear specification** — The issue explicitly defines all 4 endpoints with their request/response schemas, status codes, and all 6 test cases
+4. **Single responsibility** — All changes serve one purpose: exposing list operations via HTTP. The reorder endpoint is slightly more complex (iterating list_ids to update positions) but uses existing `update_list` method
+5. **Established patterns** — The router registration pattern in `main.py`, Pydantic models in `models.py`, and test patterns in existing test files provide clear templates to follow


### PR DESCRIPTION
## Summary

Resolves TRE-37: List API endpoints — CRUD + reorder for lists

Implements the first API router module (lists.py) with four endpoints for list management on a Trello-style kanban board. This establishes the canonical router pattern that future endpoint modules (boards, cards) will follow.

## Changes

- backend/src/app/routers/lists.py — New router module with four endpoints:
  - POST /api/lists — Create a new list with auto-assigned position (201)
  - PUT /api/lists/reorder — Reorder lists by updating positions to match submitted order
  - PUT /api/lists/{id} — Update a list title (200 or 404)
  - DELETE /api/lists/{id} — Delete a list and CASCADE to its cards (204 or 404)
- backend/src/app/main.py — Register the lists router with prefix=/api
- backend/tests/test_api_lists.py — 6 test cases covering all endpoints, 404 handling, CASCADE delete, and position management

## Verification

- Tests: PASS (53 total, 6 new — all passing)
- Lint & Format: PASS (ruff, biome, mypy, tsc)
- Deploy PR Preview: PASS
- E2E Tests: PASS

See .orca/validation-report.md for full CI details.

## Documentation

All 3 doc impact checklist items addressed:

- docs/agents/implementation.md — Added Router Implementation Pattern section documenting the 7-point canonical pattern established by lists.py
- docs/agents/design-feedback-loop.md — Added Canonical API Endpoint Test Pattern section referencing test_api_lists.py as the reference example
- README.md — Added Lists API endpoint documentation with request/response schemas

Doc validation: PASS (3/3 checklist items, all internal links valid, all code references valid, no TODO/FIXME)

## Scope

scope_score: 6/10 | Files: 3 | Subsystems: 2 (FastAPI routing layer, test infrastructure)