### PR TITLE
TRE-36: Board API endpoints — GET /api/board (nested), PUT /api/board

### DIFF
--- a/.orca/pr-url
+++ b/.orca/pr-url
@@ -1,0 +1,1 @@
+https://github.com/gutnikov/trello-clone/pull/8

--- a/.orca/state.json
+++ b/.orca/state.json
@@ -1,7 +1,7 @@
 {
   "issue": "TRE-36",
-  "agent": "design-feedback-loop",
-  "step": "completed",
+  "agent": "docs",
+  "step": "updating-docs",
   "scope_score": 6,
   "decision": "ATOMIC",
   "affected_files": [
@@ -18,17 +18,47 @@
     "doc_impact": "docs/plans/TRE-36-doc-impact.md",
     "scope": "docs/plans/TRE-36-scope.md"
   },
-  "feedback_completeness_score": 9,
   "retry_count": 0,
-  "status": "done",
+  "status": "in_progress",
   "test_files": [
     "backend/tests/test_api_boards.py"
   ],
   "test_results": {
     "new_tests_count": 7,
-    "new_tests_failed": 7,
-    "new_tests_errored": 0,
+    "new_tests_passed": 7,
+    "new_tests_failed": 0,
     "existing_tests_passed": 47,
-    "all_failures_are_assertions": true
+    "total_passed": 54,
+    "total_failed": 0
+  },
+  "implementation_summary": {
+    "files_created": ["backend/src/app/routers/boards.py"],
+    "files_modified": ["backend/src/app/main.py"],
+    "schemas_defined": ["CardResponse", "ListWithCards", "BoardDetailResponse", "BoardUpdateRequest", "BoardResponse"],
+    "endpoints": ["GET /api/board", "PUT /api/board"]
+  },
+  "validation": {
+    "pr_url": "https://github.com/gutnikov/trello-clone/pull/8",
+    "ci_result": "PASS",
+    "ci_runs": {
+      "ci": "https://github.com/gutnikov/trello-clone/actions/runs/23286343892",
+      "deploy_staging": "https://github.com/gutnikov/trello-clone/actions/runs/23286343873"
+    },
+    "jobs": {
+      "lint_format": "PASS",
+      "test": "PASS",
+      "deploy_pr_preview": "PASS",
+      "e2e_tests": "PASS"
+    }
+  },
+  "docs": {
+    "docs_updated": [
+      "docs/agents/implementation.md",
+      "docs/agents/design-feedback-loop.md",
+      "README.md",
+      "docs/agents/scoping.md"
+    ],
+    "validation": "pending",
+    "pr_url": null
   }
 }

--- a/.orca/state.json
+++ b/.orca/state.json
@@ -1,7 +1,7 @@
 {
   "issue": "TRE-36",
   "agent": "docs",
-  "step": "updating-docs",
+  "step": "completed",
   "scope_score": 6,
   "decision": "ATOMIC",
   "affected_files": [
@@ -19,7 +19,7 @@
     "scope": "docs/plans/TRE-36-scope.md"
   },
   "retry_count": 0,
-  "status": "in_progress",
+  "status": "done",
   "test_files": [
     "backend/tests/test_api_boards.py"
   ],
@@ -58,7 +58,7 @@
       "README.md",
       "docs/agents/scoping.md"
     ],
-    "validation": "pending",
-    "pr_url": null
+    "validation": "PASS",
+    "pr_url": "https://github.com/gutnikov/trello-clone/pull/8"
   }
 }

--- a/.orca/state.json
+++ b/.orca/state.json
@@ -1,42 +1,34 @@
 {
-  "issue": "TRE-35",
-  "agent": "implementation",
+  "issue": "TRE-36",
+  "agent": "design-feedback-loop",
   "step": "completed",
-  "scope_score": 4,
+  "scope_score": 6,
   "decision": "ATOMIC",
   "affected_files": [
-    "backend/src/app/routers/__init__.py",
+    "backend/src/app/routers/boards.py",
     "backend/src/app/main.py",
-    "backend/tests/conftest.py",
-    "backend/tests/test_conftest_fixtures.py"
+    "backend/tests/test_api_boards.py"
   ],
   "subsystems": [
-    "fastapi-app-layer",
-    "test-infrastructure"
+    "fastapi-app-layer"
   ],
+  "artifacts": {
+    "plan": "docs/plans/TRE-36-plan.md",
+    "feedback_loop": "docs/feedback-loops/TRE-36-feedback.md",
+    "doc_impact": "docs/plans/TRE-36-doc-impact.md",
+    "scope": "docs/plans/TRE-36-scope.md"
+  },
+  "feedback_completeness_score": 9,
   "retry_count": 0,
-  "attempt_count": 2,
-  "pr_url": "https://github.com/gutnikov/trello-clone/pull/5",
-  "ci_runs": [
-    "https://github.com/gutnikov/trello-clone/actions/runs/23285069007",
-    "https://github.com/gutnikov/trello-clone/actions/runs/23285069003"
+  "status": "done",
+  "test_files": [
+    "backend/tests/test_api_boards.py"
   ],
-  "tests_passing": [
-    "test_conftest_fixtures.py::TestDbFixture::test_db_fixture_provides_connected_database",
-    "test_conftest_fixtures.py::TestDbFixture::test_db_fixture_has_seeded_board",
-    "test_conftest_fixtures.py::TestDbFixture::test_db_fixture_isolation",
-    "test_conftest_fixtures.py::TestClientFixture::test_client_fixture_provides_async_client",
-    "test_conftest_fixtures.py::TestClientFixture::test_client_fixture_uses_test_db",
-    "test_main.py::TestCORSMiddleware::test_cors_allows_any_origin_by_default",
-    "test_main.py::TestCORSMiddleware::test_cors_preflight_returns_200",
-    "test_main.py::TestCORSMiddleware::test_cors_configured_origins_respected",
-    "test_main.py::TestLifespanLifecycle::test_app_state_has_db_after_startup",
-    "test_main.py::TestLifespanLifecycle::test_lifespan_seeds_default_board",
-    "test_main.py::TestLifespanLifecycle::test_health_endpoint_still_works"
-  ],
-  "validation_fixes": [
-    "Fixed ruff I001 import sorting violation in tests/test_main.py (removed extra blank line)",
-    "Fixed Docker startup failure by adding parent directory creation (Path.mkdir) before DB connect in lifespan"
-  ],
-  "status": "done"
+  "test_results": {
+    "new_tests_count": 7,
+    "new_tests_failed": 7,
+    "new_tests_errored": 0,
+    "existing_tests_passed": 47,
+    "all_failures_are_assertions": true
+  }
 }

--- a/.orca/validation-report.md
+++ b/.orca/validation-report.md
@@ -1,57 +1,27 @@
-# Validation Report — TRE-35
+# Validation Report — TRE-36
 
-## CI Result: FAIL
+## CI Result: PASS
 
-**PR:** https://github.com/gutnikov/trello-clone/pull/5
-**Branch:** TRE-35
+**PR:** https://github.com/gutnikov/trello-clone/pull/8
+**Branch:** TRE-36
 **CI Workflow Runs:**
-- CI: https://github.com/gutnikov/trello-clone/actions/runs/23285069007
-- Deploy Staging: https://github.com/gutnikov/trello-clone/actions/runs/23285069003
+- CI: https://github.com/gutnikov/trello-clone/actions/runs/23286343892
+- Deploy Staging: https://github.com/gutnikov/trello-clone/actions/runs/23286343873
 
 ## Job Results
 
-| Job | Status | Duration |
-|-----|--------|----------|
-| Lint & Format | FAIL | 10s |
-| Test | PASS | 13s |
-| Deploy PR Preview | FAIL | 14s |
-| E2E Tests | SKIPPED | (depends on deploy) |
-
-## Failure Details
-
-### 1. Lint & Format — FAIL (blocking)
-
-**Step:** Run pre-commit
-**Error:** `ruff` hook found 1 auto-fixable lint error and modified files:
-
-```
-ruff (legacy alias)......................................................Failed
-- hook id: ruff
-- files were modified by this hook
-
-Found 1 error (1 fixed, 0 remaining).
-```
-
-**Root cause:** There is a ruff lint violation in the backend code that ruff can auto-fix. When pre-commit runs ruff with `--fix`, it modifies files, which causes the hook to fail (signaling the file was dirty).
-
-**Fix required:** Run `cd backend && uv run ruff check src/ tests/ --fix` locally, then commit the fixed files. Alternatively, run `cd backend && uv run pre-commit run --all-files` to identify and fix the exact file/issue.
-
-### 2. Deploy PR Preview — FAIL (non-blocking for CI, but informational)
-
-**Step:** Deploy preview stack
-**Error:** Backend container exited with code 3:
-
-```
-Container preview-pr-5-backend-1 Error dependency backend failed to start
-dependency failed to start: container preview-pr-5-backend-1 exited (3)
-```
-
-**Root cause:** The backend Docker container fails to start. This could be related to the lifespan changes (DB initialization at startup) or a missing dependency in the production Docker image (e.g., `aiosqlite` or `httpx` not in non-dev dependencies). The Dockerfile uses `uv sync --no-dev --no-install-project`, so only production dependencies are installed.
-
-**Fix required:** Check that all runtime dependencies (especially `aiosqlite`) are listed as non-dev dependencies in `backend/pyproject.toml`. Also verify the backend starts correctly with the new lifespan manager when no DB file path is configured.
+| Job | Status |
+|-----|--------|
+| Lint & Format | PASS |
+| Test | PASS |
+| Deploy PR Preview | PASS |
+| E2E Tests | PASS |
 
 ## Summary
 
-Two fixes needed before CI will pass:
-1. **Fix ruff lint violation** — run ruff check/fix and commit
-2. **Fix Docker startup** — ensure production dependencies are complete and lifespan works in containerized environment
+All CI checks passed on first attempt. No issues found.
+
+- **Lint & Format:** Pre-commit hooks (ruff + biome), mypy, and tsc all clean
+- **Test:** pytest and vitest both passing
+- **Deploy PR Preview:** Staging deployment succeeded
+- **E2E Tests:** Playwright end-to-end tests passed against staging

--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ A Trello-style kanban board application.
 
 Set `CORS_ORIGINS` to your frontend domain in production (e.g., `https://app.example.com`).
 
+## API Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/health` | Health check — returns `{"status": "ok", "version": "0.1.0"}` |
+| `GET` | `/api/board` | Returns the board with all lists and cards in a nested JSON structure |
+| `PUT` | `/api/board` | Updates the board title — accepts `{"title": "..."}`, returns the updated board |
+
 ## Getting Started
 
 ```bash

--- a/backend/src/app/main.py
+++ b/backend/src/app/main.py
@@ -10,6 +10,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from app.database import Database
 from app.logging import get_logger, setup_logging
+from app.routers.boards import router as boards_router
 
 setup_logging()
 log = get_logger()
@@ -49,6 +50,9 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+app.include_router(boards_router, prefix="/api")
+log.info("router_registered", router="boards", prefix="/api")
 
 
 @app.get("/health")

--- a/backend/src/app/routers/boards.py
+++ b/backend/src/app/routers/boards.py
@@ -1,0 +1,119 @@
+"""Board API endpoints for the Trello Clone.
+
+Provides GET /board (nested response) and PUT /board (update title).
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.database import Database
+from app.logging import get_logger
+
+log = get_logger(module="routers.boards")
+
+router = APIRouter(tags=["boards"])
+
+
+# ── Response / Request Schemas ──────────────────────────────────────────
+
+
+class CardResponse(BaseModel):
+    """API response representation of a card within a list."""
+
+    model_config = ConfigDict(frozen=True)
+
+    id: str
+    title: str
+    position: int
+
+
+class ListWithCards(BaseModel):
+    """A list with its nested cards for the board detail response."""
+
+    model_config = ConfigDict(frozen=True)
+
+    id: str
+    title: str
+    position: int
+    cards: list[CardResponse]
+
+
+class BoardDetailResponse(BaseModel):
+    """Top-level nested board response for GET /api/board."""
+
+    model_config = ConfigDict(frozen=True)
+
+    id: str
+    title: str
+    lists: list[ListWithCards]
+
+
+class BoardUpdateRequest(BaseModel):
+    """Request body for PUT /api/board."""
+
+    model_config = ConfigDict(frozen=True)
+
+    title: str = Field(min_length=1)
+
+
+class BoardResponse(BaseModel):
+    """Flat board response for PUT /api/board."""
+
+    model_config = ConfigDict(frozen=True)
+
+    id: str
+    title: str
+
+
+# ── Endpoints ───────────────────────────────────────────────────────────
+
+
+@router.get("/board", response_model=BoardDetailResponse)
+async def get_board(request: Request) -> BoardDetailResponse:
+    """Return the single board with all lists and cards in a nested response."""
+    db: Database = request.app.state.db
+
+    boards = await db.list_boards()
+    if not boards:
+        raise HTTPException(status_code=404, detail="No board found")
+
+    board = boards[0]
+    lists = await db.get_lists_by_board(board.id)
+
+    lists_with_cards: list[ListWithCards] = []
+    for lst in lists:
+        cards = await db.get_cards_by_list(lst.id)
+        lists_with_cards.append(
+            ListWithCards(
+                id=lst.id,
+                title=lst.title,
+                position=lst.position,
+                cards=[CardResponse(id=c.id, title=c.title, position=c.position) for c in cards],
+            )
+        )
+
+    return BoardDetailResponse(
+        id=board.id,
+        title=board.title,
+        lists=lists_with_cards,
+    )
+
+
+@router.put("/board", response_model=BoardResponse)
+async def update_board(request: Request, body: BoardUpdateRequest) -> BoardResponse:
+    """Update the board title."""
+    db: Database = request.app.state.db
+
+    boards = await db.list_boards()
+    if not boards:
+        raise HTTPException(status_code=404, detail="No board found")
+
+    board = boards[0]
+    updated = await db.update_board(board.id, body.title)
+    if updated is None:
+        raise HTTPException(status_code=404, detail="Board not found")
+
+    log.info("board_updated", board_id=board.id, new_title=body.title)
+    return BoardResponse(id=updated.id, title=updated.title)

--- a/backend/tests/test_api_boards.py
+++ b/backend/tests/test_api_boards.py
@@ -1,0 +1,194 @@
+"""Integration tests for the board API endpoints (GET /api/board, PUT /api/board).
+
+Tests verify the nested board response structure, list/card ordering,
+board title updates, input validation, and router registration at the /api prefix.
+"""
+
+from __future__ import annotations
+
+import httpx
+
+from app.database import Database
+from app.models import Card, List
+
+
+class TestGetBoard:
+    """Tests for GET /api/board — nested board retrieval."""
+
+    async def test_get_board_returns_200_with_nested_structure(
+        self, client: httpx.AsyncClient, db: Database
+    ) -> None:
+        """GET /api/board returns 200 with id, title, and lists keys."""
+        response = await client.get("/api/board")
+
+        assert response.status_code == 200, (
+            f"Expected 200 for GET /api/board, got {response.status_code}"
+        )
+        data = response.json()
+        assert "id" in data, "Response missing 'id' key"
+        assert "title" in data, "Response missing 'title' key"
+        assert "lists" in data, "Response missing 'lists' key"
+        assert isinstance(data["id"], str), "Board 'id' should be a string"
+        assert isinstance(data["title"], str), "Board 'title' should be a string"
+        assert isinstance(data["lists"], list), "Board 'lists' should be a list"
+        assert data["title"] == "My Board", (
+            f"Expected seeded board title 'My Board', got '{data['title']}'"
+        )
+
+    async def test_get_board_includes_lists_and_cards_in_order(
+        self, client: httpx.AsyncClient, db: Database
+    ) -> None:
+        """GET /api/board returns lists and cards sorted by position."""
+        # Seed two lists with intentionally reversed positions
+        boards = await db.list_boards()
+        board_id = boards[0].id
+
+        await db.create_list(List(title="List B", board_id=board_id, position=1))
+        list_a = await db.create_list(List(title="List A", board_id=board_id, position=0))
+
+        # Seed three cards on list_a with non-sequential positions
+        await db.create_card(Card(title="Card 3", list_id=list_a.id, position=2))
+        await db.create_card(Card(title="Card 1", list_id=list_a.id, position=0))
+        await db.create_card(Card(title="Card 2", list_id=list_a.id, position=1))
+
+        response = await client.get("/api/board")
+        assert response.status_code == 200, (
+            f"Expected 200 for GET /api/board, got {response.status_code}"
+        )
+
+        data = response.json()
+        lists = data["lists"]
+        assert len(lists) >= 2, f"Expected at least 2 lists, got {len(lists)}"
+
+        # Verify lists are ordered by position (ascending)
+        for i in range(len(lists) - 1):
+            assert lists[i]["position"] < lists[i + 1]["position"], (
+                f"Lists not ordered by position: list at index {i} has position "
+                f"{lists[i]['position']} >= position {lists[i + 1]['position']} at index {i + 1}"
+            )
+
+        # Find list_a in the response and verify its cards are ordered by position
+        list_a_data = next((lst for lst in lists if lst["id"] == list_a.id), None)
+        assert list_a_data is not None, f"List A (id={list_a.id}) not found in response"
+        cards = list_a_data["cards"]
+        assert len(cards) == 3, f"Expected 3 cards in List A, got {len(cards)}"
+        for i in range(len(cards) - 1):
+            assert cards[i]["position"] < cards[i + 1]["position"], (
+                f"Cards not ordered by position: card at index {i} has position "
+                f"{cards[i]['position']} >= position {cards[i + 1]['position']} at index {i + 1}"
+            )
+
+    async def test_get_board_empty_lists_returns_empty_cards(
+        self, client: httpx.AsyncClient, db: Database
+    ) -> None:
+        """When a list has no cards, its 'cards' field is an empty list, not null or absent."""
+        boards = await db.list_boards()
+        board_id = boards[0].id
+
+        await db.create_list(List(title="Empty List", board_id=board_id, position=0))
+
+        response = await client.get("/api/board")
+        assert response.status_code == 200, (
+            f"Expected 200 for GET /api/board, got {response.status_code}"
+        )
+
+        data = response.json()
+        lists = data["lists"]
+        assert len(lists) >= 1, "Expected at least 1 list in the response"
+
+        # Find the empty list and verify its cards array
+        for lst in lists:
+            assert "cards" in lst, f"List '{lst.get('title', 'unknown')}' is missing 'cards' key"
+            assert isinstance(lst["cards"], list), (
+                f"List '{lst.get('title', 'unknown')}' 'cards' should be a list, "
+                f"got {type(lst['cards']).__name__}"
+            )
+
+        # Specifically check the list we created has an empty cards array
+        empty_list = next((lst for lst in lists if lst.get("title") == "Empty List"), None)
+        assert empty_list is not None, "Empty List not found in response"
+        assert empty_list["cards"] == [], (
+            f"Expected empty cards list for 'Empty List', got {empty_list['cards']}"
+        )
+
+
+class TestPutBoard:
+    """Tests for PUT /api/board — update board title."""
+
+    async def test_put_board_updates_title(self, client: httpx.AsyncClient, db: Database) -> None:
+        """PUT /api/board with valid title returns 200 and persists the update."""
+        boards = await db.list_boards()
+        board_id = boards[0].id
+
+        response = await client.put(
+            "/api/board",
+            json={"title": "New Title"},
+        )
+
+        assert response.status_code == 200, (
+            f"Expected 200 for PUT /api/board, got {response.status_code}"
+        )
+        data = response.json()
+        assert data["id"] == board_id, f"Expected board id '{board_id}', got '{data.get('id')}'"
+        assert data["title"] == "New Title", (
+            f"Expected title 'New Title', got '{data.get('title')}'"
+        )
+
+        # Verify persistence via subsequent GET
+        get_response = await client.get("/api/board")
+        assert get_response.status_code == 200, (
+            f"Expected 200 for GET /api/board after update, got {get_response.status_code}"
+        )
+        get_data = get_response.json()
+        assert get_data["title"] == "New Title", (
+            f"GET /api/board did not reflect updated title: got '{get_data.get('title')}'"
+        )
+
+    async def test_put_board_empty_title_returns_422(self, client: httpx.AsyncClient) -> None:
+        """PUT /api/board with empty title returns 422 due to min_length=1 validation."""
+        response = await client.put(
+            "/api/board",
+            json={"title": ""},
+        )
+
+        assert response.status_code == 422, (
+            f"Expected 422 for empty title, got {response.status_code}"
+        )
+        data = response.json()
+        assert "detail" in data, "Expected validation error 'detail' in 422 response body"
+
+    async def test_put_board_missing_title_returns_422(self, client: httpx.AsyncClient) -> None:
+        """PUT /api/board with missing title field returns 422."""
+        response = await client.put(
+            "/api/board",
+            json={},
+        )
+
+        assert response.status_code == 422, (
+            f"Expected 422 for missing title, got {response.status_code}"
+        )
+        data = response.json()
+        assert "detail" in data, "Expected validation error 'detail' in 422 response body"
+
+
+class TestBoardRouterRegistration:
+    """Tests for board router registration in main.py."""
+
+    async def test_board_endpoints_registered_at_api_prefix(
+        self, client: httpx.AsyncClient
+    ) -> None:
+        """GET /api/board returns 200 (not 404); GET /board returns 404."""
+        # The /api/board endpoint should exist
+        api_response = await client.get("/api/board")
+        assert api_response.status_code != 404, (
+            "GET /api/board returned 404 — board router not registered at /api prefix"
+        )
+        assert api_response.status_code == 200, (
+            f"Expected 200 for GET /api/board, got {api_response.status_code}"
+        )
+
+        # The /board endpoint (without prefix) should NOT exist
+        bare_response = await client.get("/board")
+        assert bare_response.status_code == 404, (
+            f"Expected 404 for GET /board (no /api prefix), got {bare_response.status_code}"
+        )

--- a/docs/agents/design-feedback-loop.md
+++ b/docs/agents/design-feedback-loop.md
@@ -26,5 +26,20 @@
 - **Available fixtures:** `db` (in-memory Database with schema + seeded default board), `client` (httpx AsyncClient wired to the test app)
 - When writing test scaffolds for API endpoint tests, use the `db` and `client` fixtures from conftest rather than creating new fixture setup. Tests can simply declare `db: Database` or `client: httpx.AsyncClient` as parameters.
 
+### API Endpoint Test Patterns
+The canonical pattern for API integration tests is established in `backend/tests/test_api_boards.py`. Follow this pattern for new endpoint tests:
+
+- **Fixtures:** Use the `client` fixture (`httpx.AsyncClient`) for HTTP requests and `db` fixture (`Database`) for test data setup. Both come from `conftest.py`.
+- **Test class grouping:** Group tests by endpoint (e.g., `TestGetBoard`, `TestPutBoard`, `TestBoardRouterRegistration`).
+- **Test coverage per endpoint:**
+  - HTTP status code (200, 404, 422)
+  - Response JSON structure (required keys, correct types)
+  - Field values and ordering (e.g., lists/cards sorted by position)
+  - Validation error responses (empty/missing required fields return 422)
+  - Persistence verification (PUT followed by GET to confirm update)
+  - Router registration (endpoint reachable at `/api/...` prefix, not at bare path)
+- **Test data setup:** The `db` fixture provides a seeded default board. Create additional test data directly via `db.create_list()` / `db.create_card()` within the test method — no extra fixtures needed.
+- **Assertion messages:** Include descriptive assertion messages to make failures easy to diagnose.
+
 ### Staging
 - **Available:** yes (per-PR Docker Compose preview deploys on `2.56.122.47`)

--- a/docs/agents/implementation.md
+++ b/docs/agents/implementation.md
@@ -58,6 +58,16 @@
 - **Lifespan:** The `lifespan` async context manager in `main.py` connects to the database, initializes the schema, seeds the default board on startup, and closes the DB on shutdown. The `Database` instance is available at `app.state.db`.
 - **Router package:** `backend/src/app/routers/__init__.py` is the router package. Add new endpoint modules (e.g., `boards.py`, `lists.py`, `cards.py`) here and include them in the app.
 
+### API Router Pattern
+The canonical pattern for implementing API routers is established in `backend/src/app/routers/boards.py`. Follow this pattern for new routers:
+
+- **Database access:** Route handlers obtain the database via `db: Database = request.app.state.db` (from the `Request` object, not dependency injection).
+- **Response/request schemas:** Define Pydantic `BaseModel` subclasses in the same router file alongside the endpoints. Use `ConfigDict(frozen=True)` on all schemas. Use `Field(min_length=1)` or similar validators for request body validation.
+- **Router declaration:** Use `APIRouter(tags=["..."])` with no prefix on the router itself. The prefix (`/api`) is set at registration in `main.py` via `app.include_router(router, prefix="/api")`.
+- **Response models:** Set `response_model=` on each route decorator for automatic response validation and OpenAPI docs.
+- **Logging:** Include structlog logging in each handler for observability (e.g., `log.info("board_updated", board_id=board.id)`).
+- **Registration:** Import the router in `main.py` and register with `app.include_router(router, prefix="/api")`. See `backend/src/app/main.py:54` for the existing registration pattern.
+
 ### Shared Test Fixtures
 - **Location:** `backend/tests/conftest.py`
 - **`db` fixture:** Provides an in-memory `Database` instance with schema initialized and the default board seeded. Function-scoped for test isolation. Use this fixture in API endpoint tests rather than creating ad-hoc database setup.

--- a/docs/agents/scoping.md
+++ b/docs/agents/scoping.md
@@ -1,1 +1,7 @@
 <!-- Project customize blocks for scoping.md -->
+
+### Scope Reference Data
+
+| Issue Type | Example | Approx. Lines | Scope Score |
+|------------|---------|---------------|-------------|
+| Single-entity router (2 endpoints + Pydantic schemas) | `backend/src/app/routers/boards.py` (TRE-36) | ~120 | 6 |

--- a/docs/feedback-loops/TRE-36-feedback.md
+++ b/docs/feedback-loops/TRE-36-feedback.md
@@ -1,0 +1,186 @@
+# Feedback Loop Plan: TRE-36
+
+## Overview
+
+Verification strategy for the board API endpoints: `GET /api/board` (nested board response with lists and cards) and `PUT /api/board` (update board title). This is the first router in the codebase, so verification also covers router registration correctness and the database access pattern from route handlers. Tests use the shared `db` and `client` fixtures from `backend/tests/conftest.py`.
+
+---
+
+## 1. Integration Tests — GET /api/board (`backend/tests/test_api_boards.py`)
+
+These tests verify the nested board retrieval endpoint returns the correct structure with lists and cards ordered by position.
+
+### Test Cases
+
+| Test Name | Expected Behavior |
+|---|---|
+| `test_get_board_returns_200_with_nested_structure` | `GET /api/board` returns 200; response body contains `id` (str), `title` (str), and `lists` (list) keys. The seeded default board ("My Board") is returned. |
+| `test_get_board_includes_lists_and_cards_in_order` | After seeding 2 lists (positions 1, 0) and 3 cards (positions 2, 0, 1) across those lists, `GET /api/board` returns lists sorted by position (0 before 1) and cards within each list sorted by position (0 before 1 before 2). Verify by checking `lists[0].position < lists[1].position` and `cards[i].position < cards[i+1].position` within each list. |
+| `test_get_board_empty_lists_returns_empty_cards` | When a board has lists but no cards, the `cards` array in each list object is an empty list `[]`, not absent or null. |
+
+### Run Command
+
+```bash
+cd backend && uv run pytest tests/test_api_boards.py -v -k "TestGetBoard"
+```
+
+---
+
+## 2. Integration Tests — PUT /api/board (`backend/tests/test_api_boards.py`)
+
+These tests verify the board title update endpoint validates input, persists changes, and returns the updated board.
+
+### Test Cases
+
+| Test Name | Expected Behavior |
+|---|---|
+| `test_put_board_updates_title` | `PUT /api/board` with body `{"title": "New Title"}` returns 200; response body contains `id` matching the default board's ID and `title` equal to `"New Title"`. A subsequent `GET /api/board` returns the updated title, confirming persistence. |
+| `test_put_board_empty_title_returns_422` | `PUT /api/board` with body `{"title": ""}` returns 422 (Unprocessable Entity) due to the `min_length=1` validation on `BoardUpdateRequest.title`. The response body contains a validation error detail. |
+| `test_put_board_missing_title_returns_422` | `PUT /api/board` with body `{}` (no `title` field) returns 422 with a validation error indicating `title` is required. |
+
+### Run Command
+
+```bash
+cd backend && uv run pytest tests/test_api_boards.py -v -k "TestPutBoard"
+```
+
+---
+
+## 3. Integration Tests — Router Registration (`backend/tests/test_api_boards.py`)
+
+These tests verify the board router is correctly registered in `main.py` and accessible at the expected URL paths.
+
+### Test Cases
+
+| Test Name | Expected Behavior |
+|---|---|
+| `test_board_endpoints_registered_at_api_prefix` | `GET /api/board` returns 200 (not 404), confirming the router is registered with the `/api` prefix. `GET /board` (without prefix) returns 404, confirming the prefix is required. |
+
+### Run Command
+
+```bash
+cd backend && uv run pytest tests/test_api_boards.py -v -k "test_board_endpoints_registered"
+```
+
+---
+
+## 4. Non-Regression — Existing Tests
+
+Verify that adding the board router and modifying `main.py` does not break existing functionality.
+
+### Test Cases
+
+| Suite | Expected Behavior |
+|---|---|
+| `tests/test_smoke.py` | `test_smoke` still passes |
+| `tests/test_models.py` | All model tests still pass (no model changes) |
+| `tests/test_database.py` | All database CRUD tests still pass (no database changes) |
+| `tests/test_main.py` | CORS and lifespan tests still pass; the new `include_router` call doesn't interfere with middleware or lifecycle |
+| `tests/test_conftest_fixtures.py` | Shared fixture tests still pass |
+
+### Run Command
+
+```bash
+cd backend && uv run pytest -v
+```
+
+---
+
+## 5. Static Analysis
+
+### Type Checking
+
+```bash
+cd backend && uv run mypy src/app/routers/boards.py src/app/main.py --strict
+```
+
+Verifies:
+- All Pydantic response/request schemas have correct field type annotations
+- Route handler functions have full parameter and return type annotations
+- `request.app.state.db` access is properly annotated with local `db: Database` variable
+- `BoardUpdateRequest` field validation uses `Field(min_length=1)` correctly
+- Import paths resolve correctly (`from app.routers.boards import router`)
+
+### Linting
+
+```bash
+cd backend && uv run ruff check src/app/routers/boards.py src/app/main.py tests/test_api_boards.py
+```
+
+Verifies:
+- Import ordering follows isort conventions (I rules)
+- Line length <= 100 characters
+- No unused imports or variables
+- Async patterns are correct (ASYNC rules)
+- Naming conventions followed (N rules)
+
+---
+
+## 6. Observability Hooks
+
+The board router includes structured logging via `structlog` for runtime observability:
+
+| Event | Log Level | Fields | Purpose |
+|---|---|---|---|
+| `board_fetched` | `info` | `board_id` | Confirms GET /api/board successfully retrieved the board and nested data |
+| `board_updated` | `info` | `board_id`, `new_title` | Confirms PUT /api/board successfully updated the board title |
+| `router_registered` | `info` | `router="boards"`, `prefix="/api"` | Logged in `main.py` at startup to confirm the board router was registered |
+
+These events extend the existing startup audit trail:
+
+```
+database_connected → schema_initialized → seed_default_board → router_registered(boards) → app_startup_complete
+```
+
+And during request handling:
+```
+board_fetched(board_id=...)   [on GET /api/board]
+board_updated(board_id=..., new_title=...)   [on PUT /api/board]
+```
+
+---
+
+## 7. Runtime Validation
+
+- **Board existence check:** Both endpoints verify that at least one board exists via `list_boards()` before proceeding. If no board is found (e.g., seed failed), they return 404 with a clear error message rather than crashing on index access.
+- **Empty title rejection:** The `BoardUpdateRequest` schema uses `Field(min_length=1)` which causes FastAPI to return 422 automatically for empty or missing title fields. This matches the `Board` domain model's `min_length=1` constraint, ensuring API-level and persistence-level validation are consistent.
+- **Response model enforcement:** Using `response_model=BoardDetailResponse` and `response_model=BoardResponse` on the route decorators ensures FastAPI validates the response structure at runtime, catching any mismatch between the handler return value and the declared schema.
+- **Position ordering guarantee:** The database methods `get_lists_by_board` and `get_cards_by_list` include `ORDER BY position` clauses. The router trusts this ordering and does not re-sort. Tests verify the ordering is correct end-to-end.
+
+---
+
+## 8. Manual Verification (Optional)
+
+For local development verification beyond automated tests:
+
+```bash
+# Start the server
+cd backend && uv run uvicorn app.main:app --reload
+
+# Test GET
+curl -s http://localhost:8000/api/board | python -m json.tool
+
+# Test PUT
+curl -s -X PUT http://localhost:8000/api/board -H "Content-Type: application/json" -d '{"title": "Updated Board"}' | python -m json.tool
+
+# Test validation (should return 422)
+curl -s -X PUT http://localhost:8000/api/board -H "Content-Type: application/json" -d '{"title": ""}' | python -m json.tool
+```
+
+---
+
+## Feedback Completeness Score
+
+| Dimension | Score (0-2) | Justification |
+|---|---|---|
+| Integration tests — GET endpoint | 2 | 3 test cases covering basic structure, ordering correctness, and empty-cards edge case |
+| Integration tests — PUT endpoint | 2 | 3 test cases covering successful update, empty title rejection, and missing title rejection |
+| Integration tests — registration | 1 | 1 test case confirming router is mounted at `/api` prefix |
+| Non-regression | 1 | Full existing test suite re-run to verify no breakage from `main.py` modification |
+| Static analysis | 1 | mypy strict + ruff linting on all new/modified files |
+| Observability | 1 | 3 structured log events for request handling and router registration |
+| Runtime validation | 1 | Board existence checks, schema validation, response model enforcement |
+
+**Total feedback_completeness_score: 9/10**
+
+The score of 9 exceeds the minimum threshold of 6. The high score reflects that this is the first API router in the codebase, establishing patterns for all subsequent endpoint implementations. Thorough verification ensures the DB access pattern, response schema approach, and test structure are correct before they're replicated in TRE-37 (lists) and TRE-38 (cards). E2e browser tests are not applicable since these are pure JSON API endpoints with no frontend component yet.

--- a/docs/plans/TRE-36-doc-impact.md
+++ b/docs/plans/TRE-36-doc-impact.md
@@ -1,0 +1,73 @@
+# Doc Impact Analysis: TRE-36
+
+## Overview
+
+TRE-36 adds the first API router to the codebase (`GET /api/board` and `PUT /api/board`). The documentation impact is focused on recording the API surface, updating agent context docs with the router pattern and response schema conventions, and ensuring the README reflects the new endpoints. No architectural decisions warrant a new ADR — the router follows standard FastAPI patterns.
+
+---
+
+## Impacted Documents
+
+### 1. `docs/agents/implementation.md` — Router Pattern and DB Access Convention
+
+- **Impact:** MEDIUM — Update recommended
+- **Reason:** TRE-36 establishes the canonical router implementation pattern: database access via `request.app.state.db`, response schemas defined in the router file, router registration with `/api` prefix in `main.py`. Future implementation agents (TRE-37 lists, TRE-38 cards) need to follow this exact pattern. The implementation agent context doc should document it explicitly.
+- **Action:** Add a section documenting:
+  - Route handlers access the database via `db: Database = request.app.state.db`
+  - Response/request Pydantic schemas are defined in the router file alongside the endpoints
+  - Routers use `APIRouter(tags=["..."])` with no prefix; the prefix `/api` is set at registration in `main.py`
+  - `response_model` is set on each route decorator for automatic response validation
+  - Structlog logging is included in each handler for observability
+
+### 2. `docs/agents/design-feedback-loop.md` — API Test Patterns
+
+- **Impact:** MEDIUM — Update recommended
+- **Reason:** TRE-36 establishes the pattern for API endpoint integration tests: use `client` fixture from `conftest.py`, test HTTP status codes + response body structure, verify persistence via follow-up GET requests, test validation by sending invalid payloads. The Design Feedback Loop Agent should know this pattern to write correct test scaffolds for future endpoint issues.
+- **Action:** Add a section documenting:
+  - API tests use the shared `client` fixture (httpx AsyncClient) and `db` fixture from `conftest.py`
+  - Test classes are grouped by endpoint (e.g., `TestGetBoard`, `TestPutBoard`)
+  - Tests verify: HTTP status code, response JSON structure, field values, ordering, and validation error responses (422)
+  - The `db` fixture provides a seeded default board; tests can add lists/cards directly via `db.create_list()` / `db.create_card()` for test data setup
+
+### 3. `README.md` — API Endpoints Documentation
+
+- **Impact:** LOW — Minor update
+- **Reason:** TRE-36 adds the first user-facing API endpoints. The README should document available endpoints for contributors and users.
+- **Action:** Add an "API Endpoints" section documenting:
+  - `GET /api/board` — Returns the board with nested lists and cards
+  - `PUT /api/board` — Updates the board title (accepts `{"title": "..."}`)
+  - `GET /health` — Health check (already exists, but group it with the new endpoints for completeness)
+
+### 4. `docs/agents/scoping.md` — Reference File for Scope Estimation
+
+- **Impact:** LOW — Optional update
+- **Reason:** Now that `backend/src/app/routers/boards.py` exists as a concrete example, the scoping agent can reference its line count and complexity when estimating scope for similar router issues (TRE-37, TRE-38).
+- **Action:** Optionally add a note that a single-entity router with 2 endpoints + schemas is approximately 60-80 lines and scores ~6 on the scope scale.
+
+---
+
+## Documents NOT Impacted
+
+| Document | Reason |
+|---|---|
+| `CLAUDE.md` | No structural changes to the project map; `routers/boards.py` falls under the existing `backend/` structure |
+| `docs/conventions/golden-principles.md` | No new conventions introduced; router patterns follow existing FastAPI standards |
+| `docs/guides/workflow-customization.md` | Orca workflow unchanged |
+| `docs/agents/validation.md` | Validation process unchanged |
+| `docs/agents/docs-update.md` | Docs process unchanged |
+| `docs/architecture/` | No architectural decisions — using standard FastAPI routers, not introducing a new pattern |
+| `docs/runbooks/` | No operational procedures changed |
+| `deploy/` configs | No deployment changes; endpoints are available on the existing server |
+| `frontend/` docs | No frontend changes |
+| `backend/src/app/models.py` | Domain models unchanged; new schemas are response-only and live in the router file |
+
+---
+
+## Summary
+
+| Document | Impact Level | Action |
+|---|---|---|
+| `docs/agents/implementation.md` | Medium | **Update** — document router pattern, DB access, schema conventions |
+| `docs/agents/design-feedback-loop.md` | Medium | **Update** — document API test patterns and fixture usage |
+| `README.md` | Low | Add API endpoints documentation section |
+| `docs/agents/scoping.md` | Low | Optional — add router scope reference data |

--- a/docs/plans/TRE-36-plan.md
+++ b/docs/plans/TRE-36-plan.md
@@ -1,0 +1,89 @@
+# Implementation Plan: TRE-36
+
+## Overview
+
+Implement the board API router with two endpoints (`GET /api/board` and `PUT /api/board`) that expose the existing database layer through a REST interface. The GET endpoint returns a nested JSON response containing the single board with all its lists and their cards, ordered by position. The PUT endpoint updates the board title with validation. This requires creating Pydantic response/request schemas in the new router file, implementing the two route handlers, registering the router in `main.py`, and writing integration tests using the existing shared test fixtures from `conftest.py`. All database methods needed already exist — no changes to the persistence layer are required.
+
+## Steps
+
+### Step 1: Define Pydantic response and request schemas in the board router file
+
+- **Files:** `backend/src/app/routers/boards.py` (new)
+- **Changes:**
+  - Create the file with a module docstring explaining it provides the board API endpoints.
+  - Define `CardResponse(BaseModel)` with fields: `id: str`, `title: str`, `position: int`. This is the API response representation of a card (no `list_id` — the nesting makes it implicit).
+  - Define `ListWithCards(BaseModel)` with fields: `id: str`, `title: str`, `position: int`, `cards: list[CardResponse]`. This embeds cards within each list for the nested response.
+  - Define `BoardDetailResponse(BaseModel)` with fields: `id: str`, `title: str`, `lists: list[ListWithCards]`. This is the top-level nested response for `GET /api/board`.
+  - Define `BoardUpdateRequest(BaseModel)` with field: `title: str = Field(min_length=1)`. This validates the PUT body — the `min_length=1` constraint matches the existing `Board` model and ensures empty titles return 422.
+  - Define `BoardResponse(BaseModel)` with fields: `id: str`, `title: str`. This is the flat response for `PUT /api/board`.
+  - All schemas should use `model_config = ConfigDict(frozen=True)` consistent with the existing domain models in `backend/src/app/models.py`.
+- **Depends on:** None
+
+### Step 2: Implement the GET /api/board endpoint
+
+- **Files:** `backend/src/app/routers/boards.py` (modify — same file from Step 1)
+- **Changes:**
+  - Create `router = APIRouter(tags=["boards"])` at module level. Do NOT set a prefix on the router itself — the prefix `/api` will be set during registration in `main.py`.
+  - Import `APIRouter`, `HTTPException`, `Request` from `fastapi`, and `Database` from `app.database`.
+  - Implement `async def get_board(request: Request) -> BoardDetailResponse`:
+    - Access the database via `db: Database = request.app.state.db`.
+    - Call `boards = await db.list_boards()` to get all boards; take the first one (the default board). If no boards exist, raise `HTTPException(status_code=404, detail="No board found")`.
+    - Call `lists = await db.get_lists_by_board(board.id)` to get lists ordered by position.
+    - For each list, call `cards = await db.get_cards_by_list(lst.id)` to get cards ordered by position.
+    - Construct and return the nested `BoardDetailResponse` with `ListWithCards` and `CardResponse` objects.
+  - Decorate with `@router.get("/board", response_model=BoardDetailResponse)`.
+- **Depends on:** Step 1
+
+### Step 3: Implement the PUT /api/board endpoint
+
+- **Files:** `backend/src/app/routers/boards.py` (modify — same file)
+- **Changes:**
+  - Implement `async def update_board(request: Request, body: BoardUpdateRequest) -> BoardResponse`:
+    - Access the database via `db: Database = request.app.state.db`.
+    - Call `boards = await db.list_boards()` to get the default board. If no boards exist, raise `HTTPException(status_code=404, detail="No board found")`.
+    - Call `updated = await db.update_board(board.id, body.title)`.
+    - If `updated` is `None`, raise `HTTPException(status_code=404, detail="Board not found")` (defensive — shouldn't happen if `list_boards` returned results).
+    - Return `BoardResponse(id=updated.id, title=updated.title)`.
+  - Decorate with `@router.put("/board", response_model=BoardResponse)`.
+  - FastAPI's request body validation will automatically return 422 for empty `title` thanks to the `min_length=1` constraint on `BoardUpdateRequest`.
+  - Add structlog logging: `log.info("board_updated", board_id=board.id, new_title=body.title)` after successful update.
+- **Depends on:** Step 1
+
+### Step 4: Register the board router in main.py
+
+- **Files:** `backend/src/app/main.py` (modify)
+- **Changes:**
+  - Add import: `from app.routers.boards import router as boards_router`.
+  - Add router registration after the CORS middleware block and before the `/health` endpoint: `app.include_router(boards_router, prefix="/api")`.
+  - This makes the endpoints available at `GET /api/board` and `PUT /api/board`.
+  - Log the router registration for observability: `log.info("router_registered", router="boards", prefix="/api")`.
+- **Depends on:** Steps 2, 3
+
+### Step 5: Write integration tests for the board API
+
+- **Files:** `backend/tests/test_api_boards.py` (new)
+- **Changes:**
+  - Add a module docstring referencing the TRE-36 feedback loop plan.
+  - Import `httpx`, `pytest` and the domain models (`Board`, `List`, `Card`) from `app.models`, and `Database` from `app.database`.
+  - Use the shared `client` and `db` fixtures from `conftest.py` — do NOT create local fixtures.
+  - Create test class `TestGetBoard`:
+    - `test_get_board_returns_200_with_nested_structure(client, db)`: Verify `GET /api/board` returns 200, response body has `id`, `title`, and `lists` keys, and `lists` is a list.
+    - `test_get_board_includes_lists_and_cards_in_order(client, db)`: Seed two lists with different positions and multiple cards per list with different positions. Verify the response returns lists in position order and cards within each list in position order.
+  - Create test class `TestPutBoard`:
+    - `test_put_board_updates_title(client, db)`: Send `PUT /api/board` with `{"title": "New Title"}`, verify 200 response with updated title. Then `GET /api/board` and verify the title persisted.
+    - `test_put_board_empty_title_returns_422(client)`: Send `PUT /api/board` with `{"title": ""}`, verify 422 response.
+  - All test functions are `async def` with full type annotations and descriptive docstrings, matching the pattern in existing test files (`test_database.py`, `test_main.py`).
+  - Use explicit assert messages for clear failure diagnostics.
+- **Depends on:** Step 4
+
+## Risk Factors
+
+- **`app.state.db` is typed as `Any`** — Starlette's `State` object uses `Any` for attribute access. Route handlers accessing `request.app.state.db` won't get type checking on the returned `Database` instance. Mitigation: add a local type annotation `db: Database = request.app.state.db` in each handler for IDE/mypy benefit, and add `# type: ignore[attr-defined]` if mypy strict mode flags the state access.
+
+- **N+1 query pattern in GET /api/board** — The nested response requires one query for the board, one for lists, and one per list for cards. For a single-board Trello clone with modest list/card counts, this is acceptable. Mitigation: if performance becomes a concern in the future, a single JOIN query could replace the per-list card queries. This is out of scope for TRE-36.
+
+- **First router registration sets a pattern** — This is the first router in the codebase. The prefix strategy (`/api` on `include_router`, no prefix on the router itself) and the DB access pattern (`request.app.state.db`) will be followed by future routers (lists, cards). If the pattern is wrong, it creates tech debt. Mitigation: the plan uses standard FastAPI idioms; the prefix-at-registration pattern is the recommended approach from FastAPI docs.
+
+- **Empty `routers/__init__.py` already exists** — The `__init__.py` in `routers/` already exists with a docstring from TRE-35. No changes needed, but verify the import `from app.routers.boards import router` works with the existing package structure.
+
+- **PUT endpoint assumes a single default board** — Both endpoints use `list_boards()[0]` to find the default board rather than accepting a board ID in the URL path. This matches the issue requirement ("Return the single board") but would need refactoring if multi-board support is added later. Mitigation: the current single-board design is intentional per the scope.

--- a/docs/plans/TRE-36-scope.md
+++ b/docs/plans/TRE-36-scope.md
@@ -1,0 +1,28 @@
+# Scope Report: TRE-36
+
+## Summary
+
+This issue implements the board router with two API endpoints: `GET /api/board` (returns the single board with nested lists and cards) and `PUT /api/board` (updates the board title). The database layer already provides all necessary CRUD methods (`list_boards`, `get_board`, `update_board`, `get_lists_by_board`, `get_cards_by_list`), so the work is confined to creating the router, adding Pydantic response schemas for the nested structure, registering the router in `main.py`, and writing tests. No schema migrations or database changes are required.
+
+## Affected Files
+
+- `backend/src/app/routers/boards.py` (new) — Board router with `GET /api/board` and `PUT /api/board` endpoints; also defines nested Pydantic response schemas (`CardResponse`, `ListWithCards`, `BoardDetailResponse`, `BoardUpdateRequest`)
+- `backend/src/app/main.py` (modify) — Add `include_router()` call to register the board router with prefix `/api`
+- `backend/tests/test_api_boards.py` (new) — Integration tests for both endpoints: nested response structure, ordering, title update, and validation error on empty title
+
+## Subsystems Involved
+
+- **FastAPI app layer** — New router module, response schemas, router registration in the application entry point, and HTTP integration tests
+
+## Scope Score: 6/10
+
+- Files: 1pt (3 files affected)
+- Subsystems: 1pt (1 subsystem — FastAPI app layer only; database layer is untouched)
+- LOC estimate: 2pt (~150-190 lines across router, schemas, registration, and tests)
+- Migration: 0pt (no schema or data migration needed)
+- API surface: 2pt (2 new public API endpoints)
+- **Total: 6/10**
+
+## Decision: ATOMIC
+
+The issue is well-scoped and self-contained. All database methods needed already exist. The work involves creating a single router file with two straightforward endpoints, adding a few lines to register it in `main.py`, and writing ~4 test cases. The three affected files are all within the same subsystem (FastAPI app layer) with clear, non-overlapping responsibilities. There are no cross-cutting concerns, no migrations, and no ambiguity in the requirements. A scope score of 6 is at the atomic threshold and does not warrant decomposition.


### PR DESCRIPTION
## Summary

- Implement `GET /api/board` endpoint returning nested board structure with lists and cards
- Implement `PUT /api/board` endpoint for updating board title with validation
- Add comprehensive tests in `test_api_boards.py` (7 tests, all passing)
- Update documentation to reflect new API router patterns and endpoints

## Changes

- **New:** `backend/src/app/routers/boards.py` — Board router with GET and PUT endpoints
- **Modified:** `backend/src/app/main.py` — Register board router with `/api` prefix
- **New:** `backend/tests/test_api_boards.py` — 7 test cases covering nested response, ordering, title update, and validation

## Pydantic Schemas

- `CardResponse` — Card serialization (id, title, position)
- `ListWithCards` — List with nested cards (id, title, position, cards)
- `BoardDetailResponse` — Full board with nested lists and cards
- `BoardUpdateRequest` — Title update request with non-empty validation
- `BoardResponse` — Simple board response (id, title)

## Documentation Updates

Per TRE-36 doc impact checklist (`docs/plans/TRE-36-doc-impact.md`):

- **`docs/agents/implementation.md`** — Added "API Router Pattern" section documenting DB access via `request.app.state.db`, schema conventions, router registration pattern, and response model usage
- **`docs/agents/design-feedback-loop.md`** — Added "API Endpoint Test Patterns" section documenting test class grouping, coverage expectations, fixture usage, and assertion conventions
- **`README.md`** — Added "API Endpoints" table documenting GET /api/board, PUT /api/board, and GET /health
- **`docs/agents/scoping.md`** — Added scope reference data for single-entity router issues (~120 lines, score 6)

## Validation

- All CI checks passed (lint, test, deploy preview, e2e)
- Doc validation: all checklist items addressed, no broken links, no TODO/FIXME

Closes TRE-36