### PR TITLE
TRE-40: Board route and read-only display components

### DIFF
--- a/.orca/state.json
+++ b/.orca/state.json
@@ -1,19 +1,25 @@
 {
-  "issue": "TRE-39",
-  "agent": "docs",
-  "step": "creating-pr",
-  "status": "in_progress",
-  "branch": "TRE-39",
-  "pr_url": "https://github.com/gutnikov/trello-clone/pull/9",
-  "pr_number": 9,
-  "push_completed": true,
-  "pr_created": true,
-  "docs_updated": [
-    "docs/plans/TRE-39-doc-impact.md",
-    "docs/architecture/adr-002-tanstack-query-state-management.md",
-    "docs/agents/implementation.md",
-    "docs/agents/design-feedback-loop.md",
-    "README.md"
+  "issue": "TRE-40",
+  "agent": "design-feedback-loop",
+  "step": "complete",
+  "status": "done",
+  "test_files_created": [
+    "frontend/tests/board-components.test.tsx",
+    "frontend/e2e/board.spec.ts"
   ],
-  "validation_result": "PASS"
+  "stub_files_created": [
+    "frontend/src/components/Board.tsx",
+    "frontend/src/components/BoardList.tsx",
+    "frontend/src/components/BoardCard.tsx",
+    "frontend/src/components/EmptyBoard.tsx"
+  ],
+  "test_results": {
+    "new_tests_total": 14,
+    "new_tests_failed": 14,
+    "new_tests_errored": 0,
+    "existing_tests_total": 34,
+    "existing_tests_passed": 34,
+    "failure_type": "assertion_errors"
+  },
+  "feedback_plan": "docs/feedback-loops/TRE-40-feedback.md"
 }

--- a/.orca/state.json
+++ b/.orca/state.json
@@ -3,7 +3,7 @@
   "agent": "implementation",
   "step": "complete",
   "status": "done",
-  "attempt": 1,
+  "attempt": 2,
   "tests_passing": {
     "board-components.test.tsx": 14,
     "smoke.test.ts": 1,
@@ -12,17 +12,14 @@
     "total": 48
   },
   "files_modified": [
-    "frontend/src/components/Board.tsx",
-    "frontend/src/components/BoardList.tsx",
-    "frontend/src/components/BoardCard.tsx",
-    "frontend/src/components/EmptyBoard.tsx",
-    "frontend/src/routes/board.tsx",
-    "frontend/src/routeTree.gen.ts",
-    "frontend/src/styles.css",
-    "frontend/vite.config.ts"
+    "frontend/e2e/board.spec.ts"
+  ],
+  "validation_fixes": [
+    "Added API-based test data seeding for E2E tests that check board-list and board-card elements",
+    "Tests now create lists/cards via POST /api/lists and POST /api/cards before navigating",
+    "Added try/finally cleanup to delete seeded data after each test"
   ],
   "commits": [
-    "608b9c9 TRE-40: implement Board, BoardList, BoardCard, and EmptyBoard components",
-    "1bb312c TRE-40: add /board route, route tree, board styles, and lint fixes"
+    "TRE-40: seed E2E tests with API data for list and card display assertions"
   ]
 }

--- a/.orca/state.json
+++ b/.orca/state.json
@@ -1,25 +1,28 @@
 {
   "issue": "TRE-40",
-  "agent": "design-feedback-loop",
+  "agent": "implementation",
   "step": "complete",
   "status": "done",
-  "test_files_created": [
-    "frontend/tests/board-components.test.tsx",
-    "frontend/e2e/board.spec.ts"
-  ],
-  "stub_files_created": [
+  "attempt": 1,
+  "tests_passing": {
+    "board-components.test.tsx": 14,
+    "smoke.test.ts": 1,
+    "api.test.ts": 22,
+    "board-store.test.ts": 11,
+    "total": 48
+  },
+  "files_modified": [
     "frontend/src/components/Board.tsx",
     "frontend/src/components/BoardList.tsx",
     "frontend/src/components/BoardCard.tsx",
-    "frontend/src/components/EmptyBoard.tsx"
+    "frontend/src/components/EmptyBoard.tsx",
+    "frontend/src/routes/board.tsx",
+    "frontend/src/routeTree.gen.ts",
+    "frontend/src/styles.css",
+    "frontend/vite.config.ts"
   ],
-  "test_results": {
-    "new_tests_total": 14,
-    "new_tests_failed": 14,
-    "new_tests_errored": 0,
-    "existing_tests_total": 34,
-    "existing_tests_passed": 34,
-    "failure_type": "assertion_errors"
-  },
-  "feedback_plan": "docs/feedback-loops/TRE-40-feedback.md"
+  "commits": [
+    "608b9c9 TRE-40: implement Board, BoardList, BoardCard, and EmptyBoard components",
+    "1bb312c TRE-40: add /board route, route tree, board styles, and lint fixes"
+  ]
 }

--- a/.orca/state.json
+++ b/.orca/state.json
@@ -1,25 +1,19 @@
 {
   "issue": "TRE-40",
-  "agent": "implementation",
+  "agent": "docs",
   "step": "complete",
   "status": "done",
-  "attempt": 2,
-  "tests_passing": {
-    "board-components.test.tsx": 14,
-    "smoke.test.ts": 1,
-    "api.test.ts": 22,
-    "board-store.test.ts": 11,
-    "total": 48
+  "doc_updates": [
+    "docs/plans/TRE-40-doc-impact.md — created doc impact checklist",
+    "docs/agents/implementation.md — added frontend component pattern, route pattern, SSR/API proxy, pre-commit hooks",
+    "docs/agents/design-feedback-loop.md — added frontend component test pattern, E2E data seeding pattern"
+  ],
+  "validation": {
+    "file_references_checked": 52,
+    "broken_references": 0,
+    "todo_fixme_found": 0,
+    "broken_links": 0,
+    "result": "PASS"
   },
-  "files_modified": [
-    "frontend/e2e/board.spec.ts"
-  ],
-  "validation_fixes": [
-    "Added API-based test data seeding for E2E tests that check board-list and board-card elements",
-    "Tests now create lists/cards via POST /api/lists and POST /api/cards before navigating",
-    "Added try/finally cleanup to delete seeded data after each test"
-  ],
-  "commits": [
-    "TRE-40: seed E2E tests with API data for list and card display assertions"
-  ]
+  "pr_url": "https://github.com/gutnikov/trello-clone/pull/10"
 }

--- a/docs/agents/design-feedback-loop.md
+++ b/docs/agents/design-feedback-loop.md
@@ -17,6 +17,12 @@
 - **Pattern:** Mock `fetch` to return controlled `Response` objects, then assert the API function returns the correct typed result or throws on error responses. Each API function gets its own `describe` block.
 - **Board store tests:** `frontend/tests/board-store.test.ts` — tests React Query hooks by wrapping them in a `QueryClientProvider` and asserting on query/mutation behavior.
 
+### Frontend Component Tests
+- **Canonical example:** `frontend/tests/board-components.test.tsx` — demonstrates testing React display components using `@testing-library/react` with `vitest` and `jsdom`.
+- **Pattern:** Use `render()` to mount the component, `screen.getByText()` / `screen.getByTestId()` to find elements, and `within()` for scoped queries inside specific containers. Each component gets its own `describe` block covering export verification and rendering behavior.
+- **Props setup:** Construct typed props objects with test data (board with lists, list with cards, etc.) and pass them directly to the component under test.
+- **Position ordering:** Test that items render in `position` order by verifying DOM node order via `getAllByTestId()`.
+
 ### E2E Tests
 - Location: `frontend/e2e/`
 - Framework: Playwright
@@ -25,6 +31,7 @@
 - Run locally: `cd frontend && pnpm e2e` (auto-starts dev server)
 - Run against staging: `cd frontend && BASE_URL=http://2.56.122.47:400N pnpm e2e`
 - Headed mode: `cd frontend && pnpm e2e:headed`
+- **E2E data seeding pattern:** `frontend/e2e/board.spec.ts` demonstrates seeding test data via the API before assertions and cleaning up afterward. Use `page.request.post("/api/...")` to create lists/cards, wrap assertions in `try/finally` to ensure cleanup via `page.request.delete(...)`, and use `timeout` options on `toBeVisible()` for SSR data loading.
 
 ### Shared Test Fixtures
 - **Location:** `backend/tests/conftest.py`

--- a/docs/agents/implementation.md
+++ b/docs/agents/implementation.md
@@ -104,6 +104,42 @@ Follow the pattern in `frontend/src/lib/board-store.ts`:
 
 See `docs/architecture/adr-002-tanstack-query-state-management.md` for the architectural rationale.
 
+### Frontend Component Pattern
+
+All display components follow the pattern established in `frontend/src/components/Board.tsx`, `BoardList.tsx`, `BoardCard.tsx`, and `EmptyBoard.tsx`:
+
+1. **Named exports** — Components use named exports (e.g., `export function Board()`), not default exports.
+2. **TypeScript props interfaces** — Define a `{Component}Props` interface above the component. Inline child type definitions when the shape is local (e.g., `CardData`, `ListData`).
+3. **`data-testid` attributes** — Add `data-testid` attributes to key container elements for E2E test selectors (e.g., `data-testid="board-list"`, `data-testid="board-card"`, `data-testid="empty-board"`).
+4. **Tailwind CSS** — Use Tailwind utility classes for styling. Reference semantic color tokens (`text-foreground`, `bg-muted/60`, `border-border`, etc.) defined in `frontend/src/styles.css`.
+5. **Position-based ordering** — When rendering ordered items (cards within a list), sort by `position` field before mapping: `[...items].sort((a, b) => a.position - b.position)`.
+
+### Frontend Route Pattern
+
+Routes use TanStack Router's file-based routing. See `frontend/src/routes/board.tsx` for the canonical example:
+
+1. **`createFileRoute`** — Define the route with `createFileRoute("/path")({ component: PageComponent })`.
+2. **Data fetching** — Use React Query hooks (e.g., `useBoard()` from `frontend/src/lib/board-store.ts`) inside the page component.
+3. **Loading/error/empty states** — Handle all three states: loading spinner, error message, and empty state component. Check `isLoading`, then `error`, then empty data before rendering the main content.
+4. **Route tree** — After adding a new route file, regenerate the route tree (`frontend/src/routeTree.gen.ts`) by running `cd frontend && pnpm routes:generate` or starting the dev server (auto-generates).
+
+### SSR and API Proxy
+
+The frontend supports server-side rendering with API data:
+
+- **API proxy** (`frontend/server.js`): In production/staging, `server.js` proxies all `/api/*` requests to the backend service at `API_URL` (defaults to `http://localhost:8000`). This eliminates CORS issues and allows SSR fetch to use the same URL scheme.
+- **SSR-aware base URL** (`frontend/src/lib/api.ts`): The `getApiBase()` function detects server vs. client context. On the server (`typeof window === "undefined"`), it reads `process.env.API_URL` for direct backend access. On the client, it uses the relative `/api` path (proxied by `server.js`).
+- **Router SSR integration** (`frontend/src/router.tsx`): The router creates a `QueryClient` and passes it via `context: { queryClient }`. The `setupRouterSsrQueryIntegration` from `@tanstack/react-router-ssr-query` handles query dehydration/hydration between server and client.
+
+### Pre-commit Type Checks
+
+The `.pre-commit-config.yaml` includes type-checking hooks that run automatically on commit:
+
+- **`mypy`** — Runs `mypy src/` on backend Python files (`backend/src/`)
+- **`tsc --noEmit`** — Runs TypeScript compilation check on frontend source files (`frontend/src/`)
+
+These complement the existing `biome` and `ruff` linting hooks.
+
 ### Shared Test Fixtures
 - **Location:** `backend/tests/conftest.py`
 - **`db` fixture:** Provides an in-memory `Database` instance with schema initialized and the default board seeded. Function-scoped for test isolation. Use this fixture in API endpoint tests rather than creating ad-hoc database setup.

--- a/docs/feedback-loops/TRE-40-feedback.md
+++ b/docs/feedback-loops/TRE-40-feedback.md
@@ -1,0 +1,128 @@
+# Feedback Loop Plan: TRE-40
+
+## Overview
+
+Verification strategy for the board route and read-only display components. This issue creates:
+- `frontend/src/routes/board.tsx` — `/board` route using TanStack Router
+- `frontend/src/components/Board.tsx` — Main board layout with horizontal scroll
+- `frontend/src/components/BoardList.tsx` — List column with title and cards
+- `frontend/src/components/BoardCard.tsx` — Card displaying title
+- `frontend/src/components/EmptyBoard.tsx` — Empty state when no lists exist
+- `frontend/src/styles.css` (modification) — Board layout styles
+
+Tests verify that components export correctly, render the expected DOM structure, and the `/board` route is accessible.
+
+---
+
+## 1. Unit Tests — Component Exports (`frontend/tests/board-components.test.tsx`)
+
+These tests verify that all board display components are exported as valid React components from their respective modules.
+
+### Test Cases
+
+| Test Name | Expected Behavior |
+|---|---|
+| `Board is exported as a function component` | `Board.tsx` exports a default or named `Board` component |
+| `BoardList is exported as a function component` | `BoardList.tsx` exports a default or named `BoardList` component |
+| `BoardCard is exported as a function component` | `BoardCard.tsx` exports a default or named `BoardCard` component |
+| `EmptyBoard is exported as a function component` | `EmptyBoard.tsx` exports a default or named `EmptyBoard` component |
+
+### Run Command
+
+```bash
+cd frontend && pnpm vitest run tests/board-components.test.tsx
+```
+
+---
+
+## 2. Unit Tests — Component Rendering (`frontend/tests/board-components.test.tsx`)
+
+These tests verify the rendering behavior of each component using `@testing-library/react` with jsdom.
+
+### Test Cases
+
+| Test Name | Expected Behavior |
+|---|---|
+| `Board renders board title` | Given board data with title "My Board", renders the title text |
+| `Board renders lists horizontally in a scrollable container` | Given board data with lists, renders a container with `overflow-x: auto` or equivalent class |
+| `Board renders BoardList for each list` | Given board data with 3 lists, renders 3 list columns |
+| `BoardList renders list title` | Given a list with title "To Do", renders "To Do" text |
+| `BoardList renders BoardCard for each card` | Given a list with 2 cards, renders 2 card elements |
+| `BoardList renders cards ordered by position` | Given cards with positions [2, 0, 1], renders them in position order |
+| `BoardCard renders card title` | Given a card with title "Fix bug", renders "Fix bug" text |
+| `EmptyBoard renders empty state message` | When no lists exist, renders a prompt to create the first list |
+| `EmptyBoard contains call-to-action text` | Renders text encouraging user to create a list |
+
+### Run Command
+
+```bash
+cd frontend && pnpm vitest run tests/board-components.test.tsx
+```
+
+---
+
+## 3. E2E Tests — Board Route (`frontend/e2e/board.spec.ts`)
+
+These tests verify the `/board` route is accessible and renders board data correctly.
+
+### Test Cases
+
+| Test Name | Expected Behavior |
+|---|---|
+| `board page loads at /board` | Navigating to `/board` does not return a 404 |
+| `board page displays board title` | The board title is visible on the page |
+| `board page displays lists when board has lists` | List titles are visible on the board |
+| `board page displays cards within lists` | Card titles are visible within their parent lists |
+| `board page shows empty state when no lists exist` | When board has no lists, empty state message is shown |
+
+### Run Command
+
+```bash
+cd frontend && pnpm e2e e2e/board.spec.ts
+```
+
+---
+
+## 4. Non-Regression Tests
+
+Verify existing tests still pass after adding new test files.
+
+### Test Suites
+
+| Suite | File | Expected |
+|---|---|---|
+| Smoke | `tests/smoke.test.ts` | 1 test passes |
+| API Client | `tests/api.test.ts` | All tests pass |
+| Board Store | `tests/board-store.test.ts` | All tests pass |
+
+### Run Command
+
+```bash
+cd frontend && pnpm vitest run
+```
+
+---
+
+## 5. Static Analysis
+
+### Linting
+
+```bash
+cd frontend && pnpm lint
+```
+
+---
+
+## Feedback Completeness Score
+
+| Dimension | Score (0-2) | Justification |
+|---|---|---|
+| Unit tests — component exports | 2 | 4 export verification tests for all components |
+| Unit tests — component rendering | 2 | 9 rendering behavior tests covering all components |
+| E2E tests — route accessibility | 2 | 5 tests covering route, board display, and empty state |
+| Non-regression | 1 | Full existing test suite re-run |
+| Static analysis | 1 | Biome linting on all new/modified files |
+
+**Total feedback_completeness_score: 8/10**
+
+The score of 8 exceeds the minimum threshold of 6. This is a UI layer with visual components, so E2E tests are included.

--- a/docs/plans/TRE-40-doc-impact.md
+++ b/docs/plans/TRE-40-doc-impact.md
@@ -1,0 +1,59 @@
+# Doc Impact Analysis: TRE-40
+
+## Overview
+
+TRE-40 introduces the board route and read-only display components — the first frontend UI layer for the Trello clone. This includes four React components (`Board`, `BoardList`, `BoardCard`, `EmptyBoard`), a `/board` route using TanStack Router, an API proxy in `server.js` for production SSR, and SSR-aware API base URL resolution.
+
+---
+
+## Impacted Documents
+
+### 1. `docs/agents/implementation.md` — Frontend Component & Route Patterns
+
+- **Impact:** HIGH — Update required
+- **Reason:** TRE-40 creates the first frontend components and route. Future agents building UI features need to know the component structure pattern, the route creation pattern, and the SSR/API proxy architecture.
+- **Action:** Add sections documenting:
+  - Frontend component pattern: named exports, TypeScript interfaces for props, `data-testid` attributes, Tailwind CSS classes
+  - Route creation pattern: `createFileRoute` with `useBoard()` hook, loading/error/empty states
+  - SSR + API proxy: `server.js` proxies `/api/*` to backend, `api.ts` uses `getApiBase()` for SSR vs client URL resolution
+  - Router SSR integration: `QueryClient` creation in `router.tsx` with `setupRouterSsrQueryIntegration`
+
+### 2. `docs/agents/design-feedback-loop.md` — Frontend Component Test Patterns
+
+- **Impact:** MEDIUM — Update required
+- **Reason:** TRE-40 adds the first frontend component tests (`frontend/tests/board-components.test.tsx`) using `@testing-library/react`. The design feedback loop agent doc should reference this as the canonical pattern for future component test scaffolds.
+- **Action:** Add a subsection documenting:
+  - Component test pattern using `@testing-library/react` with `render`, `screen`, and `within`
+  - E2E test pattern with API-based data seeding and cleanup (`frontend/e2e/board.spec.ts`)
+
+### 3. `docs/agents/implementation.md` — Pre-commit Hooks
+
+- **Impact:** LOW — Minor update
+- **Reason:** TRE-40 adds `mypy` and `tsc --noEmit` pre-commit hooks. Agents should know these run automatically on commit.
+- **Action:** Mention the pre-commit type-checking hooks under the existing Style section.
+
+---
+
+## Documents NOT Impacted
+
+| Document | Reason |
+|---|---|
+| `CLAUDE.md` | No structural changes to the project map |
+| `docs/conventions/golden-principles.md` | No new conventions introduced |
+| `docs/guides/workflow-customization.md` | Orca workflow unchanged |
+| `docs/agents/scoping.md` | Scoping process unchanged |
+| `docs/agents/planning.md` | Planning process unchanged |
+| `docs/agents/validation.md` | Validation process unchanged |
+| `docs/agents/docs-update.md` | Docs process unchanged |
+| `docs/architecture/` | No new architectural decisions — components follow standard React patterns, SSR proxy is standard infrastructure |
+| `docs/runbooks/deploy-prod.md` | API proxy is transparent to deployment — same Docker Compose setup |
+| `README.md` | No new API endpoints or configuration changes |
+
+---
+
+## Summary
+
+| Document | Impact Level | Action |
+|---|---|---|
+| `docs/agents/implementation.md` | High | **Update** — add frontend component pattern, route pattern, SSR/API proxy, pre-commit hooks |
+| `docs/agents/design-feedback-loop.md` | Medium | **Update** — add frontend component test pattern and E2E data seeding pattern |

--- a/frontend/e2e/board.spec.ts
+++ b/frontend/e2e/board.spec.ts
@@ -4,7 +4,8 @@
  * These tests verify that the /board route is accessible and renders
  * board data correctly, including lists, cards, and empty state.
  *
- * All tests are expected to FAIL until the implementation is written.
+ * Tests that require lists/cards seed their own data via the API
+ * and clean up afterwards to maintain test isolation.
  */
 import { expect, test } from "@playwright/test";
 
@@ -28,25 +29,56 @@ test.describe("Board page", () => {
   });
 
   test("board page displays lists when board has lists", async ({ page }) => {
-    await page.goto("/board");
+    // Seed a list via the API so the board has data to display
+    const boardRes = await page.request.get("/api/board");
+    const board = await boardRes.json();
+    const listRes = await page.request.post("/api/lists", {
+      data: { title: "E2E Test List", board_id: board.id },
+    });
+    const list = await listRes.json();
 
-    // Wait for board data to load — look for any list column element
-    const listColumn = page.locator("[data-testid='board-list']");
-    await expect(
-      listColumn.first(),
-      "Board page should display at least one list when the board has lists",
-    ).toBeVisible({ timeout: 10000 });
+    try {
+      await page.goto("/board");
+
+      // Wait for board data to load — look for any list column element
+      const listColumn = page.locator("[data-testid='board-list']");
+      await expect(
+        listColumn.first(),
+        "Board page should display at least one list when the board has lists",
+      ).toBeVisible({ timeout: 10000 });
+    } finally {
+      // Clean up: delete the test list
+      await page.request.delete(`/api/lists/${list.id}`);
+    }
   });
 
   test("board page displays cards within lists", async ({ page }) => {
-    await page.goto("/board");
+    // Seed a list and card via the API so the board has data to display
+    const boardRes = await page.request.get("/api/board");
+    const board = await boardRes.json();
+    const listRes = await page.request.post("/api/lists", {
+      data: { title: "E2E Test List for Cards", board_id: board.id },
+    });
+    const list = await listRes.json();
+    const cardRes = await page.request.post("/api/cards", {
+      data: { title: "E2E Test Card", list_id: list.id },
+    });
+    const card = await cardRes.json();
 
-    // Wait for board data to load — look for card elements inside lists
-    const card = page.locator("[data-testid='board-card']");
-    await expect(
-      card.first(),
-      "Board page should display cards within lists",
-    ).toBeVisible({ timeout: 10000 });
+    try {
+      await page.goto("/board");
+
+      // Wait for board data to load — look for card elements inside lists
+      const cardElement = page.locator("[data-testid='board-card']");
+      await expect(
+        cardElement.first(),
+        "Board page should display cards within lists",
+      ).toBeVisible({ timeout: 10000 });
+    } finally {
+      // Clean up: delete the test card and list
+      await page.request.delete(`/api/cards/${card.id}`);
+      await page.request.delete(`/api/lists/${list.id}`);
+    }
   });
 
   test("board page shows empty state when no lists exist", async ({ page }) => {

--- a/frontend/e2e/board.spec.ts
+++ b/frontend/e2e/board.spec.ts
@@ -1,0 +1,74 @@
+/**
+ * TRE-40: E2E tests for /board route and read-only display components.
+ *
+ * These tests verify that the /board route is accessible and renders
+ * board data correctly, including lists, cards, and empty state.
+ *
+ * All tests are expected to FAIL until the implementation is written.
+ */
+import { expect, test } from "@playwright/test";
+
+test.describe("Board page", () => {
+  test("board page loads at /board", async ({ page }) => {
+    const response = await page.goto("/board");
+
+    // The route should not return a 404
+    expect(response?.status(), "Board page should not return 404").not.toBe(404);
+  });
+
+  test("board page displays board title", async ({ page }) => {
+    await page.goto("/board");
+
+    // The board title should be visible somewhere on the page
+    const heading = page.getByRole("heading");
+    await expect(
+      heading.first(),
+      "Board page should display a heading with the board title",
+    ).toBeVisible();
+  });
+
+  test("board page displays lists when board has lists", async ({ page }) => {
+    await page.goto("/board");
+
+    // Wait for board data to load — look for any list column element
+    const listColumn = page.locator("[data-testid='board-list']");
+    await expect(
+      listColumn.first(),
+      "Board page should display at least one list when the board has lists",
+    ).toBeVisible({ timeout: 10000 });
+  });
+
+  test("board page displays cards within lists", async ({ page }) => {
+    await page.goto("/board");
+
+    // Wait for board data to load — look for card elements inside lists
+    const card = page.locator("[data-testid='board-card']");
+    await expect(
+      card.first(),
+      "Board page should display cards within lists",
+    ).toBeVisible({ timeout: 10000 });
+  });
+
+  test("board page shows empty state when no lists exist", async ({ page }) => {
+    // This test assumes the board starts empty or can be made empty
+    // The empty state component should show a message about creating lists
+    await page.goto("/board");
+
+    // If the board has no lists, it should show the empty state
+    // We check for the presence of either lists or the empty state message
+    const hasLists = await page
+      .locator("[data-testid='board-list']")
+      .first()
+      .isVisible()
+      .catch(() => false);
+
+    if (!hasLists) {
+      // Should show empty state when no lists exist
+      const emptyState = page.locator("[data-testid='empty-board']");
+      await expect(
+        emptyState,
+        "Board page should show empty state when no lists exist",
+      ).toBeVisible({ timeout: 5000 });
+    }
+  });
+});

--- a/frontend/server.js
+++ b/frontend/server.js
@@ -1,4 +1,4 @@
-import { createServer } from "node:http";
+import { createServer, request as httpRequest } from "node:http";
 import { Readable } from "node:stream";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -9,6 +9,7 @@ const { default: handler } = await import("./dist/server/server.js");
 
 const PORT = parseInt(process.env.PORT || "3000", 10);
 const HOST = process.env.HOST || "0.0.0.0";
+const API_URL = new URL(process.env.API_URL || "http://localhost:8000");
 
 // Serve static assets from dist/client before falling through to SSR.
 // Hashed filenames in /assets/ get immutable caching (1 year).
@@ -20,6 +21,37 @@ const serve = sirv(path.join(__dirname, "dist/client"), {
 });
 
 const server = createServer((req, res) => {
+  // Proxy /api/* requests to the backend service
+  if (req.url?.startsWith("/api")) {
+    const proxyReq = httpRequest(
+      {
+        hostname: API_URL.hostname,
+        port: API_URL.port || 80,
+        path: req.url,
+        method: req.method,
+        headers: {
+          ...req.headers,
+          host: API_URL.host,
+        },
+      },
+      (proxyRes) => {
+        res.writeHead(proxyRes.statusCode ?? 502, proxyRes.headers);
+        proxyRes.pipe(res);
+      },
+    );
+
+    proxyReq.on("error", (err) => {
+      console.error("API proxy error:", err);
+      if (!res.headersSent) {
+        res.writeHead(502, { "Content-Type": "text/plain" });
+      }
+      res.end("Bad Gateway");
+    });
+
+    req.pipe(proxyReq);
+    return;
+  }
+
   // Try static files first; fall through to SSR handler if no match
   serve(req, res, async () => {
     try {

--- a/frontend/src/components/Board.tsx
+++ b/frontend/src/components/Board.tsx
@@ -1,2 +1,40 @@
-// TRE-40: Board component — implementation pending
-export {};
+import { BoardList } from "@/components/BoardList";
+
+interface CardData {
+  id: string;
+  title: string;
+  position: number;
+}
+
+interface ListData {
+  id: string;
+  title: string;
+  position: number;
+  cards: CardData[];
+}
+
+interface BoardProps {
+  board: {
+    id: string;
+    title: string;
+    lists: ListData[];
+  };
+}
+
+export function Board({ board }: BoardProps) {
+  return (
+    <div className="flex h-full flex-col">
+      <h1 className="px-6 py-4 text-2xl font-bold text-foreground">
+        {board.title}
+      </h1>
+      <div
+        data-testid="board-lists-container"
+        className="flex flex-1 gap-4 overflow-x-auto px-6 pb-6"
+      >
+        {board.lists.map((list) => (
+          <BoardList key={list.id} list={list} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/Board.tsx
+++ b/frontend/src/components/Board.tsx
@@ -1,0 +1,2 @@
+// TRE-40: Board component — implementation pending
+export {};

--- a/frontend/src/components/Board.tsx
+++ b/frontend/src/components/Board.tsx
@@ -24,9 +24,7 @@ interface BoardProps {
 export function Board({ board }: BoardProps) {
   return (
     <div className="flex h-full flex-col">
-      <h1 className="px-6 py-4 text-2xl font-bold text-foreground">
-        {board.title}
-      </h1>
+      <h1 className="px-6 py-4 text-2xl font-bold text-foreground">{board.title}</h1>
       <div
         data-testid="board-lists-container"
         className="flex flex-1 gap-4 overflow-x-auto px-6 pb-6"

--- a/frontend/src/components/BoardCard.tsx
+++ b/frontend/src/components/BoardCard.tsx
@@ -1,0 +1,2 @@
+// TRE-40: BoardCard component — implementation pending
+export {};

--- a/frontend/src/components/BoardCard.tsx
+++ b/frontend/src/components/BoardCard.tsx
@@ -1,2 +1,18 @@
-// TRE-40: BoardCard component — implementation pending
-export {};
+interface BoardCardProps {
+  card: {
+    id: string;
+    title: string;
+    position: number;
+  };
+}
+
+export function BoardCard({ card }: BoardCardProps) {
+  return (
+    <div
+      data-testid="board-card"
+      className="rounded-lg border border-border bg-card px-3 py-2 text-sm text-card-foreground shadow-sm"
+    >
+      {card.title}
+    </div>
+  );
+}

--- a/frontend/src/components/BoardList.tsx
+++ b/frontend/src/components/BoardList.tsx
@@ -1,0 +1,2 @@
+// TRE-40: BoardList component — implementation pending
+export {};

--- a/frontend/src/components/BoardList.tsx
+++ b/frontend/src/components/BoardList.tsx
@@ -1,2 +1,36 @@
-// TRE-40: BoardList component — implementation pending
-export {};
+import { BoardCard } from "@/components/BoardCard";
+
+interface CardData {
+  id: string;
+  title: string;
+  position: number;
+}
+
+interface BoardListProps {
+  list: {
+    id: string;
+    title: string;
+    position: number;
+    cards: CardData[];
+  };
+}
+
+export function BoardList({ list }: BoardListProps) {
+  const sortedCards = [...list.cards].sort((a, b) => a.position - b.position);
+
+  return (
+    <div
+      data-testid="board-list"
+      className="flex w-72 shrink-0 flex-col rounded-xl bg-muted/60 p-3"
+    >
+      <h3 className="mb-3 px-1 text-sm font-semibold text-foreground">
+        {list.title}
+      </h3>
+      <div className="flex flex-col gap-2">
+        {sortedCards.map((card) => (
+          <BoardCard key={card.id} card={card} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/BoardList.tsx
+++ b/frontend/src/components/BoardList.tsx
@@ -23,9 +23,7 @@ export function BoardList({ list }: BoardListProps) {
       data-testid="board-list"
       className="flex w-72 shrink-0 flex-col rounded-xl bg-muted/60 p-3"
     >
-      <h3 className="mb-3 px-1 text-sm font-semibold text-foreground">
-        {list.title}
-      </h3>
+      <h3 className="mb-3 px-1 text-sm font-semibold text-foreground">{list.title}</h3>
       <div className="flex flex-col gap-2">
         {sortedCards.map((card) => (
           <BoardCard key={card.id} card={card} />

--- a/frontend/src/components/EmptyBoard.tsx
+++ b/frontend/src/components/EmptyBoard.tsx
@@ -1,2 +1,15 @@
-// TRE-40: EmptyBoard component — implementation pending
-export {};
+export function EmptyBoard() {
+  return (
+    <div
+      data-testid="empty-board"
+      className="flex flex-col items-center justify-center px-4 py-20 text-center"
+    >
+      <h2 className="mb-2 text-xl font-semibold text-foreground">
+        No lists yet
+      </h2>
+      <p className="max-w-sm text-muted-foreground">
+        Create your first list to get started organizing your tasks.
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/components/EmptyBoard.tsx
+++ b/frontend/src/components/EmptyBoard.tsx
@@ -1,0 +1,2 @@
+// TRE-40: EmptyBoard component — implementation pending
+export {};

--- a/frontend/src/components/EmptyBoard.tsx
+++ b/frontend/src/components/EmptyBoard.tsx
@@ -4,9 +4,7 @@ export function EmptyBoard() {
       data-testid="empty-board"
       className="flex flex-col items-center justify-center px-4 py-20 text-center"
     >
-      <h2 className="mb-2 text-xl font-semibold text-foreground">
-        No lists yet
-      </h2>
+      <h2 className="mb-2 text-xl font-semibold text-foreground">No lists yet</h2>
       <p className="max-w-sm text-muted-foreground">
         Create your first list to get started organizing your tasks.
       </p>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -72,7 +72,18 @@ interface ApiErrorResponse {
   detail: string;
 }
 
-const API_BASE = "/api";
+function getApiBase(): string {
+  if (typeof window === "undefined") {
+    // Server-side (SSR): use the backend URL directly
+    // eslint-disable-next-line no-process-env
+    const backendUrl = process.env.API_URL || "http://localhost:8000";
+    return `${backendUrl}/api`;
+  }
+  // Client-side: use relative URL (goes through the server proxy)
+  return "/api";
+}
+
+const API_BASE = getApiBase();
 
 async function handleResponse<T>(response: Response): Promise<T> {
   if (!response.ok) {

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -9,9 +9,15 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as BoardRouteImport } from './routes/board'
 import { Route as AboutRouteImport } from './routes/about'
 import { Route as IndexRouteImport } from './routes/index'
 
+const BoardRoute = BoardRouteImport.update({
+  id: '/board',
+  path: '/board',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const AboutRoute = AboutRouteImport.update({
   id: '/about',
   path: '/about',
@@ -26,31 +32,42 @@ const IndexRoute = IndexRouteImport.update({
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/about': typeof AboutRoute
+  '/board': typeof BoardRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/about': typeof AboutRoute
+  '/board': typeof BoardRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/about': typeof AboutRoute
+  '/board': typeof BoardRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/about'
+  fullPaths: '/' | '/about' | '/board'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/about'
-  id: '__root__' | '/' | '/about'
+  to: '/' | '/about' | '/board'
+  id: '__root__' | '/' | '/about' | '/board'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   AboutRoute: typeof AboutRoute
+  BoardRoute: typeof BoardRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/board': {
+      id: '/board'
+      path: '/board'
+      fullPath: '/board'
+      preLoaderRoute: typeof BoardRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/about': {
       id: '/about'
       path: '/about'
@@ -71,6 +88,7 @@ declare module '@tanstack/react-router' {
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   AboutRoute: AboutRoute,
+  BoardRoute: BoardRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -1,14 +1,20 @@
+import { QueryClient } from "@tanstack/react-query";
 import { createRouter as createTanStackRouter } from "@tanstack/react-router";
+import { setupRouterSsrQueryIntegration } from "@tanstack/react-router-ssr-query";
 import { routeTree } from "./routeTree.gen";
 
 export function getRouter() {
+  const queryClient = new QueryClient();
+
   const router = createTanStackRouter({
     routeTree,
-
+    context: { queryClient },
     scrollRestoration: true,
     defaultPreload: "intent",
     defaultPreloadStaleTime: 0,
   });
+
+  setupRouterSsrQueryIntegration({ router, queryClient });
 
   return router;
 }

--- a/frontend/src/routes/board.tsx
+++ b/frontend/src/routes/board.tsx
@@ -1,0 +1,45 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { Board } from "@/components/Board";
+import { EmptyBoard } from "@/components/EmptyBoard";
+import { useBoard } from "@/lib/board-store";
+
+export const Route = createFileRoute("/board")({ component: BoardPage });
+
+function BoardPage() {
+  const { data: board, isLoading, error } = useBoard();
+
+  if (isLoading) {
+    return (
+      <main className="flex min-h-[calc(100dvh-4rem)] items-center justify-center">
+        <p className="text-muted-foreground">Loading board...</p>
+      </main>
+    );
+  }
+
+  if (error) {
+    return (
+      <main className="flex min-h-[calc(100dvh-4rem)] items-center justify-center">
+        <p className="text-destructive">Failed to load board.</p>
+      </main>
+    );
+  }
+
+  if (!board) {
+    return null;
+  }
+
+  if (board.lists.length === 0) {
+    return (
+      <main className="min-h-[calc(100dvh-4rem)]">
+        <h1 className="px-6 py-4 text-2xl font-bold text-foreground">{board.title}</h1>
+        <EmptyBoard />
+      </main>
+    );
+  }
+
+  return (
+    <main className="min-h-[calc(100dvh-4rem)]">
+      <Board board={board} />
+    </main>
+  );
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -188,3 +188,22 @@
 .rise-in {
   animation: rise-in 600ms cubic-bezier(0.16, 1, 0.3, 1) both;
 }
+
+/* Board layout — horizontal scroll container for list columns */
+[data-testid="board-lists-container"] {
+  scrollbar-width: thin;
+  scrollbar-color: var(--border) transparent;
+}
+
+[data-testid="board-lists-container"]::-webkit-scrollbar {
+  height: 8px;
+}
+
+[data-testid="board-lists-container"]::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+[data-testid="board-lists-container"]::-webkit-scrollbar-thumb {
+  background-color: var(--border);
+  border-radius: 4px;
+}

--- a/frontend/tests/board-components.test.tsx
+++ b/frontend/tests/board-components.test.tsx
@@ -1,0 +1,307 @@
+// @vitest-environment jsdom
+// @ts-nocheck — Intentional: tests reference exports that don't exist yet (TDD fail-first)
+/**
+ * TRE-40: Fail-first tests for board display components.
+ *
+ * These tests verify that the Board, BoardList, BoardCard, and EmptyBoard
+ * components are exported correctly and render the expected DOM structure.
+ *
+ * All tests are expected to FAIL until the implementation is written.
+ */
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import * as BoardModule from "@/components/Board";
+import * as BoardListModule from "@/components/BoardList";
+import * as BoardCardModule from "@/components/BoardCard";
+import * as EmptyBoardModule from "@/components/EmptyBoard";
+
+// ── Test Data ──────────────────────────────────────────────────────────────
+
+const mockBoardData = {
+  id: "b1",
+  title: "My Board",
+  lists: [
+    {
+      id: "l1",
+      title: "To Do",
+      position: 0,
+      cards: [
+        { id: "c1", title: "Task 1", position: 0 },
+        { id: "c2", title: "Task 2", position: 1 },
+      ],
+    },
+    {
+      id: "l2",
+      title: "In Progress",
+      position: 1,
+      cards: [{ id: "c3", title: "Task 3", position: 0 }],
+    },
+    {
+      id: "l3",
+      title: "Done",
+      position: 2,
+      cards: [],
+    },
+  ],
+};
+
+// ── Component Export Tests ─────────────────────────────────────────────────
+
+describe("Board component exports", () => {
+  it("Board is exported as a function component", () => {
+    expect(
+      BoardModule.Board,
+      "Board.tsx should export a named 'Board' component",
+    ).toBeDefined();
+    expect(
+      typeof BoardModule.Board,
+      "Board should be a function component",
+    ).toBe("function");
+  });
+
+  it("BoardList is exported as a function component", () => {
+    expect(
+      BoardListModule.BoardList,
+      "BoardList.tsx should export a named 'BoardList' component",
+    ).toBeDefined();
+    expect(
+      typeof BoardListModule.BoardList,
+      "BoardList should be a function component",
+    ).toBe("function");
+  });
+
+  it("BoardCard is exported as a function component", () => {
+    expect(
+      BoardCardModule.BoardCard,
+      "BoardCard.tsx should export a named 'BoardCard' component",
+    ).toBeDefined();
+    expect(
+      typeof BoardCardModule.BoardCard,
+      "BoardCard should be a function component",
+    ).toBe("function");
+  });
+
+  it("EmptyBoard is exported as a function component", () => {
+    expect(
+      EmptyBoardModule.EmptyBoard,
+      "EmptyBoard.tsx should export a named 'EmptyBoard' component",
+    ).toBeDefined();
+    expect(
+      typeof EmptyBoardModule.EmptyBoard,
+      "EmptyBoard should be a function component",
+    ).toBe("function");
+  });
+});
+
+// ── Board Component Rendering Tests ───────────────────────────────────────
+
+describe("Board component rendering", () => {
+  it("renders board title", () => {
+    const Board = BoardModule.Board;
+    expect(Board, "Board component must be exported before rendering tests can run").toBeDefined();
+
+    render(React.createElement(Board, { board: mockBoardData }));
+
+    expect(
+      screen.getByText("My Board"),
+      "Board should display the board title",
+    ).toBeDefined();
+  });
+
+  it("renders a scrollable container for lists", () => {
+    const Board = BoardModule.Board;
+    expect(Board, "Board component must be exported before rendering tests can run").toBeDefined();
+
+    const { container } = render(
+      React.createElement(Board, { board: mockBoardData }),
+    );
+
+    // The board should have a horizontally scrollable container
+    const scrollContainer = container.querySelector(
+      "[data-testid='board-lists-container']",
+    );
+    expect(
+      scrollContainer,
+      "Board should render a lists container with data-testid='board-lists-container'",
+    ).not.toBeNull();
+  });
+
+  it("renders a BoardList for each list in the board", () => {
+    const Board = BoardModule.Board;
+    expect(Board, "Board component must be exported before rendering tests can run").toBeDefined();
+
+    render(React.createElement(Board, { board: mockBoardData }));
+
+    // All three list titles should be rendered
+    expect(
+      screen.getByText("To Do"),
+      "Board should render the 'To Do' list",
+    ).toBeDefined();
+    expect(
+      screen.getByText("In Progress"),
+      "Board should render the 'In Progress' list",
+    ).toBeDefined();
+    expect(
+      screen.getByText("Done"),
+      "Board should render the 'Done' list",
+    ).toBeDefined();
+  });
+});
+
+// ── BoardList Component Rendering Tests ───────────────────────────────────
+
+describe("BoardList component rendering", () => {
+  it("renders list title", () => {
+    const BoardList = BoardListModule.BoardList;
+    expect(BoardList, "BoardList component must be exported before rendering tests can run").toBeDefined();
+
+    render(
+      React.createElement(BoardList, {
+        list: mockBoardData.lists[0],
+      }),
+    );
+
+    expect(
+      screen.getByText("To Do"),
+      "BoardList should display the list title",
+    ).toBeDefined();
+  });
+
+  it("renders a BoardCard for each card in the list", () => {
+    const BoardList = BoardListModule.BoardList;
+    expect(BoardList, "BoardList component must be exported before rendering tests can run").toBeDefined();
+
+    render(
+      React.createElement(BoardList, {
+        list: mockBoardData.lists[0],
+      }),
+    );
+
+    // The "To Do" list has 2 cards
+    expect(
+      screen.getByText("Task 1"),
+      "BoardList should render the first card",
+    ).toBeDefined();
+    expect(
+      screen.getByText("Task 2"),
+      "BoardList should render the second card",
+    ).toBeDefined();
+  });
+
+  it("renders cards ordered by position", () => {
+    const BoardList = BoardListModule.BoardList;
+    expect(BoardList, "BoardList component must be exported before rendering tests can run").toBeDefined();
+
+    const unorderedList = {
+      id: "l1",
+      title: "Test List",
+      position: 0,
+      cards: [
+        { id: "c3", title: "Third", position: 2 },
+        { id: "c1", title: "First", position: 0 },
+        { id: "c2", title: "Second", position: 1 },
+      ],
+    };
+
+    const { container } = render(
+      React.createElement(BoardList, { list: unorderedList }),
+    );
+
+    // Get all card elements and verify order
+    const cardElements = container.querySelectorAll(
+      "[data-testid='board-card']",
+    );
+    expect(
+      cardElements.length,
+      "BoardList should render 3 cards",
+    ).toBe(3);
+
+    // Cards should appear in position order: First, Second, Third
+    expect(
+      cardElements[0]?.textContent,
+      "First card by position should be 'First'",
+    ).toContain("First");
+    expect(
+      cardElements[1]?.textContent,
+      "Second card by position should be 'Second'",
+    ).toContain("Second");
+    expect(
+      cardElements[2]?.textContent,
+      "Third card by position should be 'Third'",
+    ).toContain("Third");
+  });
+});
+
+// ── BoardCard Component Rendering Tests ───────────────────────────────────
+
+describe("BoardCard component rendering", () => {
+  it("renders card title", () => {
+    const BoardCard = BoardCardModule.BoardCard;
+    expect(BoardCard, "BoardCard component must be exported before rendering tests can run").toBeDefined();
+
+    render(
+      React.createElement(BoardCard, {
+        card: { id: "c1", title: "Fix bug", position: 0 },
+      }),
+    );
+
+    expect(
+      screen.getByText("Fix bug"),
+      "BoardCard should display the card title",
+    ).toBeDefined();
+  });
+
+  it("renders with data-testid attribute", () => {
+    const BoardCard = BoardCardModule.BoardCard;
+    expect(BoardCard, "BoardCard component must be exported before rendering tests can run").toBeDefined();
+
+    const { container } = render(
+      React.createElement(BoardCard, {
+        card: { id: "c1", title: "Fix bug", position: 0 },
+      }),
+    );
+
+    const cardEl = container.querySelector("[data-testid='board-card']");
+    expect(
+      cardEl,
+      "BoardCard should render with data-testid='board-card'",
+    ).not.toBeNull();
+  });
+});
+
+// ── EmptyBoard Component Rendering Tests ──────────────────────────────────
+
+describe("EmptyBoard component rendering", () => {
+  it("renders empty state message", () => {
+    const EmptyBoard = EmptyBoardModule.EmptyBoard;
+    expect(EmptyBoard, "EmptyBoard component must be exported before rendering tests can run").toBeDefined();
+
+    render(React.createElement(EmptyBoard));
+
+    // Should contain some prompt about creating a list
+    const body = document.body.textContent || "";
+    expect(
+      body.toLowerCase(),
+      "EmptyBoard should contain text about creating a list",
+    ).toContain("list");
+  });
+
+  it("contains call-to-action text encouraging list creation", () => {
+    const EmptyBoard = EmptyBoardModule.EmptyBoard;
+    expect(EmptyBoard, "EmptyBoard component must be exported before rendering tests can run").toBeDefined();
+
+    render(React.createElement(EmptyBoard));
+
+    // Should contain encouraging text about getting started or creating first list
+    const body = document.body.textContent || "";
+    const hasCtaText =
+      body.toLowerCase().includes("create") ||
+      body.toLowerCase().includes("add") ||
+      body.toLowerCase().includes("get started");
+    expect(
+      hasCtaText,
+      "EmptyBoard should contain call-to-action text (create/add/get started)",
+    ).toBe(true);
+  });
+});

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -17,6 +17,7 @@ const config = defineConfig({
   ],
   test: {
     exclude: ['e2e/**', 'node_modules/**'],
+    globals: true,
   },
 })
 


### PR DESCRIPTION
## Summary

- Implements the `/board` route using TanStack Router `createFileRoute`
- Creates read-only display components: `Board`, `BoardList`, `BoardCard`, and `EmptyBoard`
- Adds horizontal scroll container for board layout with proper CSS styling
- Fetches board data via the `useBoard` hook from board-store
- Renders `EmptyBoard` when no lists exist (US-1)

## Components

| Component | Description |
|---|---|
| `Board.tsx` | Main board layout with horizontal scroll container |
| `BoardList.tsx` | List column with title and cards |
| `BoardCard.tsx` | Card component displaying card title |
| `EmptyBoard.tsx` | Empty state prompting user to create first list |
| `board.tsx` (route) | `/board` route fetching data via `useBoard` |

## Infrastructure

- API proxy in `server.js` forwards `/api/*` to backend for SSR + production
- SSR-aware `getApiBase()` in `api.ts` uses `API_URL` env var on server, relative `/api` on client
- Router SSR integration via `setupRouterSsrQueryIntegration` with `QueryClient` in context
- Added `mypy` and `tsc --noEmit` pre-commit hooks

## Documentation Changes

- **`docs/plans/TRE-40-doc-impact.md`** — Created doc impact checklist
- **`docs/agents/implementation.md`** — Added frontend component pattern, route pattern, SSR/API proxy architecture, pre-commit type-checking hooks
- **`docs/agents/design-feedback-loop.md`** — Added frontend component test pattern, E2E data seeding pattern

### Doc Validation: PASS
- 52 file path references checked, 0 broken
- 0 TODO/FIXME markers found
- 0 broken internal links

## Acceptance Criteria

- [x] /board route is accessible and renders board data from API
- [x] Lists display horizontally with horizontal scrolling
- [x] Cards display within their parent lists ordered by position
- [x] EmptyBoard renders when no lists exist (US-1)
- [x] Board title displays at the top

Closes TRE-40